### PR TITLE
Another refactor

### DIFF
--- a/pdfium/internal/commons/pdfium-plugin.go
+++ b/pdfium/internal/commons/pdfium-plugin.go
@@ -1,103 +1,24 @@
 package commons
 
 import (
-	"image"
 	"net/rpc"
+
+	"github.com/klippa-app/go-pdfium/pdfium/requests"
+	"github.com/klippa-app/go-pdfium/pdfium/responses"
 
 	"github.com/hashicorp/go-plugin"
 )
 
-type OpenDocumentRequest struct {
-	File *[]byte
-}
-
-type RenderPageInDPIRequest struct {
-	Page int
-	DPI  int
-}
-
-type RenderPageInPixelsRequest struct {
-	Page   int
-	Width  int
-	Height int
-}
-
-type RenderPageResponse struct {
-	Image *image.RGBA
-}
-
-type GetPageSizeRequest struct {
-	Page int
-}
-
-type GetPageSizeInPixelsRequest struct {
-	Page int
-	DPI  int
-}
-
-type GetPageSizeResponse struct {
-	Width  float64
-	Height float64
-}
-
-type GetPageSizeInPixelsResponse struct {
-	Width  int
-	Height int
-}
-
-type GetPageTextRequest struct {
-	Page int
-}
-
-type GetPageTextResponse struct {
-	Text *string
-}
-
-type GetPageTextStructuredRequest struct {
-	Page int
-	Mode GetPageTextStructuredRequestMode
-}
-
-type GetPageTextStructuredRequestMode string
-
-const (
-	GetPageTextStructuredRequestModeChars GetPageTextStructuredRequestMode = "char"
-	GetPageTextStructuredRequestModeRects GetPageTextStructuredRequestMode = "rect"
-	GetPageTextStructuredRequestModeBoth  GetPageTextStructuredRequestMode = "both"
-)
-
-type GetPageTextStructuredResponseChar struct {
-	Text   string
-	Left   float64
-	Top    float64
-	Right  float64
-	Bottom float64
-	Angle  float64
-}
-
-type GetPageTextStructuredResponseRect struct {
-	Text   string
-	Left   float64
-	Top    float64
-	Right  float64
-	Bottom float64
-}
-
-type GetPageTextStructuredResponse struct {
-	Chars []*GetPageTextStructuredResponseChar
-	Rects []*GetPageTextStructuredResponseRect
-}
-
 type Pdfium interface {
 	Ping() (string, error)
-	OpenDocument(*OpenDocumentRequest) error
-	GetPageCount() (int, error)
-	GetPageText(*GetPageTextRequest) (GetPageTextResponse, error)
-	GetPageTextStructured(*GetPageTextStructuredRequest) (GetPageTextStructuredResponse, error)
-	RenderPageInDPI(*RenderPageInDPIRequest) (RenderPageResponse, error)
-	RenderPageInPixels(*RenderPageInPixelsRequest) (RenderPageResponse, error)
-	GetPageSize(*GetPageSizeRequest) (GetPageSizeResponse, error)
-	GetPageSizeInPixels(*GetPageSizeInPixelsRequest) (GetPageSizeInPixelsResponse, error)
+	OpenDocument(*requests.OpenDocument) error
+	GetPageCount(*requests.GetPageCount) (*responses.GetPageCount, error)
+	GetPageText(*requests.GetPageText) (*responses.GetPageText, error)
+	GetPageTextStructured(*requests.GetPageTextStructured) (*responses.GetPageTextStructured, error)
+	RenderPageInDPI(*requests.RenderPageInDPI) (*responses.RenderPage, error)
+	RenderPageInPixels(*requests.RenderPageInPixels) (*responses.RenderPage, error)
+	GetPageSize(*requests.GetPageSize) (*responses.GetPageSize, error)
+	GetPageSizeInPixels(*requests.GetPageSizeInPixels) (*responses.GetPageSizeInPixels, error)
 	Close() error
 }
 
@@ -113,7 +34,7 @@ func (g *PdfiumRPC) Ping() (string, error) {
 	return resp, nil
 }
 
-func (g *PdfiumRPC) OpenDocument(request *OpenDocumentRequest) error {
+func (g *PdfiumRPC) OpenDocument(request *requests.OpenDocument) error {
 	err := g.client.Call("Plugin.OpenDocument", request, new(interface{}))
 	if err != nil {
 		return err
@@ -122,71 +43,71 @@ func (g *PdfiumRPC) OpenDocument(request *OpenDocumentRequest) error {
 	return nil
 }
 
-func (g *PdfiumRPC) GetPageCount() (int, error) {
-	var resp int
-	err := g.client.Call("Plugin.GetPageCount", new(interface{}), &resp)
+func (g *PdfiumRPC) GetPageCount(request *requests.GetPageCount) (*responses.GetPageCount, error) {
+	resp := &responses.GetPageCount{}
+	err := g.client.Call("Plugin.GetPageCount", request, resp)
 	if err != nil {
-		return 0, err
+		return nil, err
 	}
 
 	return resp, nil
 }
 
-func (g *PdfiumRPC) GetPageText(request *GetPageTextRequest) (GetPageTextResponse, error) {
-	var resp GetPageTextResponse
-	err := g.client.Call("Plugin.GetPageText", request, &resp)
+func (g *PdfiumRPC) GetPageText(request *requests.GetPageText) (*responses.GetPageText, error) {
+	resp := &responses.GetPageText{}
+	err := g.client.Call("Plugin.GetPageText", request, resp)
 	if err != nil {
-		return resp, err
+		return nil, err
 	}
 
 	return resp, nil
 }
 
-func (g *PdfiumRPC) GetPageTextStructured(request *GetPageTextStructuredRequest) (GetPageTextStructuredResponse, error) {
-	var resp GetPageTextStructuredResponse
-	err := g.client.Call("Plugin.GetPageTextStructured", request, &resp)
+func (g *PdfiumRPC) GetPageTextStructured(request *requests.GetPageTextStructured) (*responses.GetPageTextStructured, error) {
+	resp := &responses.GetPageTextStructured{}
+	err := g.client.Call("Plugin.GetPageTextStructured", request, resp)
 	if err != nil {
-		return resp, err
+		return nil, err
 	}
 
 	return resp, nil
 }
 
-func (g *PdfiumRPC) RenderPageInDPI(request *RenderPageInDPIRequest) (RenderPageResponse, error) {
-	var resp RenderPageResponse
-	err := g.client.Call("Plugin.RenderPageInDPI", request, &resp)
+func (g *PdfiumRPC) RenderPageInDPI(request *requests.RenderPageInDPI) (*responses.RenderPage, error) {
+	resp := &responses.RenderPage{}
+	err := g.client.Call("Plugin.RenderPageInDPI", request, resp)
 	if err != nil {
-		return resp, err
+		return nil, err
 	}
 
 	return resp, nil
 }
 
-func (g *PdfiumRPC) RenderPageInPixels(request *RenderPageInPixelsRequest) (RenderPageResponse, error) {
-	var resp RenderPageResponse
-	err := g.client.Call("Plugin.RenderPageInPixels", request, &resp)
+func (g *PdfiumRPC) RenderPageInPixels(request *requests.RenderPageInPixels) (*responses.RenderPage, error) {
+	resp := &responses.RenderPage{}
+	err := g.client.Call("Plugin.RenderPageInPixels", request, resp)
 	if err != nil {
-		return resp, err
+		return nil, err
 	}
 
 	return resp, nil
 }
 
-func (g *PdfiumRPC) GetPageSize(request *GetPageSizeRequest) (GetPageSizeResponse, error) {
-	var resp GetPageSizeResponse
-	err := g.client.Call("Plugin.GetPageSize", request, &resp)
+func (g *PdfiumRPC) GetPageSize(request *requests.GetPageSize) (*responses.GetPageSize, error) {
+	resp := &responses.GetPageSize{}
+	err := g.client.Call("Plugin.GetPageSize", request, resp)
 	if err != nil {
-		return resp, err
+		return nil, err
 	}
 
 	return resp, nil
 }
 
-func (g *PdfiumRPC) GetPageSizeInPixels(request *GetPageSizeInPixelsRequest) (GetPageSizeInPixelsResponse, error) {
-	var resp GetPageSizeInPixelsResponse
-	err := g.client.Call("Plugin.GetPageSizeInPixels", request, &resp)
+func (g *PdfiumRPC) GetPageSizeInPixels(request *requests.GetPageSizeInPixels) (*responses.GetPageSizeInPixels, error) {
+	resp := &responses.GetPageSizeInPixels{}
+	err := g.client.Call("Plugin.GetPageSizeInPixels", request, resp)
 	if err != nil {
-		return resp, err
+		return nil, err
 	}
 
 	return resp, nil
@@ -214,7 +135,7 @@ func (s *PdfiumRPCServer) Ping(args interface{}, resp *string) error {
 	return nil
 }
 
-func (s *PdfiumRPCServer) OpenDocument(request *OpenDocumentRequest, resp *interface{}) error {
+func (s *PdfiumRPCServer) OpenDocument(request *requests.OpenDocument, resp *interface{}) error {
 	var err error
 	err = s.Impl.OpenDocument(request)
 	if err != nil {
@@ -223,71 +144,93 @@ func (s *PdfiumRPCServer) OpenDocument(request *OpenDocumentRequest, resp *inter
 	return nil
 }
 
-func (s *PdfiumRPCServer) GetPageCount(args interface{}, resp *int) error {
+func (s *PdfiumRPCServer) GetPageCount(request *requests.GetPageCount, resp *responses.GetPageCount) error {
 	var err error
-	*resp, err = s.Impl.GetPageCount()
+	implResp, err := s.Impl.GetPageCount(request)
 	if err != nil {
 		return err
 	}
-	return nil
-}
 
-func (s *PdfiumRPCServer) GetPageText(request *GetPageTextRequest, resp *GetPageTextResponse) error {
-	var err error
-	*resp, err = s.Impl.GetPageText(request)
-	if err != nil {
-		return err
-	}
+	// Overwrite the target address of resp to the target address of implResp.
+	*resp = *implResp
 
 	return nil
 }
 
-func (s *PdfiumRPCServer) GetPageTextStructured(request *GetPageTextStructuredRequest, resp *GetPageTextStructuredResponse) error {
+func (s *PdfiumRPCServer) GetPageText(request *requests.GetPageText, resp *responses.GetPageText) error {
 	var err error
-	*resp, err = s.Impl.GetPageTextStructured(request)
+	implResp, err := s.Impl.GetPageText(request)
 	if err != nil {
 		return err
 	}
+
+	// Overwrite the target address of resp to the target address of implResp.
+	*resp = *implResp
 
 	return nil
 }
 
-func (s *PdfiumRPCServer) RenderPageInDPI(request *RenderPageInDPIRequest, resp *RenderPageResponse) error {
+func (s *PdfiumRPCServer) GetPageTextStructured(request *requests.GetPageTextStructured, resp *responses.GetPageTextStructured) error {
 	var err error
-	*resp, err = s.Impl.RenderPageInDPI(request)
+	implResp, err := s.Impl.GetPageTextStructured(request)
 	if err != nil {
 		return err
 	}
+
+	// Overwrite the target address of resp to the target address of implResp.
+	*resp = *implResp
 
 	return nil
 }
 
-func (s *PdfiumRPCServer) RenderPageInPixels(request *RenderPageInPixelsRequest, resp *RenderPageResponse) error {
+func (s *PdfiumRPCServer) RenderPageInDPI(request *requests.RenderPageInDPI, resp *responses.RenderPage) error {
 	var err error
-	*resp, err = s.Impl.RenderPageInPixels(request)
+	implResp, err := s.Impl.RenderPageInDPI(request)
 	if err != nil {
 		return err
 	}
+
+	// Overwrite the target address of resp to the target address of implResp.
+	*resp = *implResp
 
 	return nil
 }
 
-func (s *PdfiumRPCServer) GetPageSize(request *GetPageSizeRequest, resp *GetPageSizeResponse) error {
+func (s *PdfiumRPCServer) RenderPageInPixels(request *requests.RenderPageInPixels, resp *responses.RenderPage) error {
 	var err error
-	*resp, err = s.Impl.GetPageSize(request)
+	implResp, err := s.Impl.RenderPageInPixels(request)
 	if err != nil {
 		return err
 	}
+
+	// Overwrite the target address of resp to the target address of implResp.
+	*resp = *implResp
 
 	return nil
 }
 
-func (s *PdfiumRPCServer) GetPageSizeInPixels(request *GetPageSizeInPixelsRequest, resp *GetPageSizeInPixelsResponse) error {
+func (s *PdfiumRPCServer) GetPageSize(request *requests.GetPageSize, resp *responses.GetPageSize) error {
 	var err error
-	*resp, err = s.Impl.GetPageSizeInPixels(request)
+	implResp, err := s.Impl.GetPageSize(request)
 	if err != nil {
 		return err
 	}
+
+	// Overwrite the target address of resp to the target address of implResp.
+	*resp = *implResp
+
+	return nil
+}
+
+func (s *PdfiumRPCServer) GetPageSizeInPixels(request *requests.GetPageSizeInPixels, resp *responses.GetPageSizeInPixels) error {
+	var err error
+	implResp, err := s.Impl.GetPageSizeInPixels(request)
+	if err != nil {
+		return err
+	}
+
+	// Overwrite the target address of resp to the target address of implResp.
+	*resp = *implResp
 
 	return nil
 }

--- a/pdfium/internal/subprocess/document.go
+++ b/pdfium/internal/subprocess/document.go
@@ -6,76 +6,38 @@ import "C"
 
 import (
 	"errors"
-	"sync"
-	"unsafe"
+	"github.com/klippa-app/go-pdfium/pdfium/requests"
+	"github.com/klippa-app/go-pdfium/pdfium/responses"
 )
 
-var currentDoc *Document
-
-// Document is good
-type Document struct {
-	// C data
-	doc  C.FPDF_DOCUMENT
-	page C.FPDF_PAGE
-
-	currentPage *int    // Remember which page is currently loaded in the page variable.
-	data        *[]byte // Keep a reference to the data otherwise weird stuff happens
-}
-
-var mutex = &sync.Mutex{}
-
-// NewDocument creates a new pdfium doc from a byte array
-func NewDocument(data *[]byte) (*Document, error) {
-	mutex.Lock()
-	defer mutex.Unlock()
-	doc := C.FPDF_LoadMemDocument(
-		unsafe.Pointer(&((*data)[0])),
-		C.int(len(*data)),
-		nil)
-
-	if doc == nil {
-		var errMsg string
-
-		errorCode := C.FPDF_GetLastError()
-		switch errorCode {
-		case C.FPDF_ERR_SUCCESS:
-			errMsg = "Success"
-		case C.FPDF_ERR_UNKNOWN:
-			errMsg = "Unknown error"
-		case C.FPDF_ERR_FILE:
-			errMsg = "Unable to read file"
-		case C.FPDF_ERR_FORMAT:
-			errMsg = "Incorrect format"
-		case C.FPDF_ERR_PASSWORD:
-			errMsg = "Invalid password"
-		case C.FPDF_ERR_SECURITY:
-			errMsg = "Invalid encryption"
-		case C.FPDF_ERR_PAGE:
-			errMsg = "Incorrect page"
-		default:
-			errMsg = "Unexpected error"
-		}
-		return nil, errors.New(errMsg)
-	}
-	return &Document{doc: doc, data: data}, nil
-}
-
 // GetPageCount counts the amount of pages
-func (d *Document) GetPageCount() int {
-	mutex.Lock()
-	defer mutex.Unlock()
-	return int(C.FPDF_GetPageCount(d.doc))
+func (p *Pdfium) GetPageCount(request *requests.GetPageCount) (*responses.GetPageCount, error) {
+	if p.currentDoc == nil {
+		return nil, errors.New("no current document")
+	}
+
+	p.Lock()
+	defer p.Unlock()
+	return &responses.GetPageCount{
+		PageCount: int(C.FPDF_GetPageCount(p.currentDoc.doc)),
+	}, nil
 }
 
 // Close closes the internal references in FPDF
-func (d *Document) Close() {
-	mutex.Lock()
-	if d.currentPage != nil {
-		C.FPDF_ClosePage(d.page)
-		d.page = nil
-		d.currentPage = nil
+func (p *Pdfium) Close() error {
+	if p.currentDoc == nil {
+		return errors.New("no current document")
 	}
-	C.FPDF_CloseDocument(d.doc)
-	d.doc = nil
-	mutex.Unlock()
+
+	p.Lock()
+	if p.currentDoc.currentPage != nil {
+		C.FPDF_ClosePage(p.currentDoc.page)
+		p.currentDoc.page = nil
+		p.currentDoc.currentPage = nil
+	}
+	C.FPDF_CloseDocument(p.currentDoc.doc)
+	p.currentDoc.doc = nil
+	p.currentDoc = nil
+	p.Unlock()
+	return nil
 }

--- a/pdfium/internal/subprocess/document.go
+++ b/pdfium/internal/subprocess/document.go
@@ -20,7 +20,7 @@ func (p *Pdfium) GetPageCount(request *requests.GetPageCount) (*responses.GetPag
 	p.Lock()
 	defer p.Unlock()
 	return &responses.GetPageCount{
-		PageCount: int(C.FPDF_GetPageCount(p.currentDoc.doc)),
+		PageCount: int(C.FPDF_GetPageCount(p.currentDoc)),
 	}, nil
 }
 
@@ -31,13 +31,12 @@ func (p *Pdfium) Close() error {
 	}
 
 	p.Lock()
-	if p.currentDoc.currentPage != nil {
-		C.FPDF_ClosePage(p.currentDoc.page)
-		p.currentDoc.page = nil
-		p.currentDoc.currentPage = nil
+	if p.currentPageNumber != nil {
+		C.FPDF_ClosePage(p.currentPage)
+		p.currentPage = nil
+		p.currentPageNumber = nil
 	}
-	C.FPDF_CloseDocument(p.currentDoc.doc)
-	p.currentDoc.doc = nil
+	C.FPDF_CloseDocument(p.currentDoc)
 	p.currentDoc = nil
 	p.Unlock()
 	return nil

--- a/pdfium/internal/subprocess/document.go
+++ b/pdfium/internal/subprocess/document.go
@@ -6,6 +6,7 @@ import "C"
 
 import (
 	"errors"
+
 	"github.com/klippa-app/go-pdfium/pdfium/requests"
 	"github.com/klippa-app/go-pdfium/pdfium/responses"
 )

--- a/pdfium/internal/subprocess/page.go
+++ b/pdfium/internal/subprocess/page.go
@@ -8,21 +8,21 @@ import "C"
 // One point is 1/72 inch (around 0.3528 mm)
 func (p *Pdfium) loadPage(page int) {
 	// Already loaded this page.
-	if p.currentDoc.currentPage != nil && *p.currentDoc.currentPage == page {
+	if p.currentPageNumber != nil && *p.currentPageNumber == page {
 		return
 	}
 
 	p.Lock()
-	if p.currentDoc.currentPage != nil {
+	if p.currentPageNumber != nil {
 		// Unload the current page.
-		C.FPDF_ClosePage(p.currentDoc.page)
-		p.currentDoc.page = nil
-		p.currentDoc.currentPage = nil
+		C.FPDF_ClosePage(p.currentPage)
+		p.currentPage = nil
+		p.currentPageNumber = nil
 	}
 
-	pageObject := C.FPDF_LoadPage(p.currentDoc.doc, C.int(page))
-	p.currentDoc.page = pageObject
-	p.currentDoc.currentPage = &page
+	pageObject := C.FPDF_LoadPage(p.currentDoc, C.int(page))
+	p.currentPage = pageObject
+	p.currentPageNumber = &page
 	p.Unlock()
 
 	return

--- a/pdfium/internal/subprocess/page.go
+++ b/pdfium/internal/subprocess/page.go
@@ -6,24 +6,24 @@ import "C"
 
 // GetPageSize returns the page size in points
 // One point is 1/72 inch (around 0.3528 mm)
-func (d *Document) loadPage(page int) {
+func (p *Pdfium) loadPage(page int) {
 	// Already loaded this page.
-	if d.currentPage != nil && *d.currentPage == page {
+	if p.currentDoc.currentPage != nil && *p.currentDoc.currentPage == page {
 		return
 	}
 
-	mutex.Lock()
-	if d.currentPage != nil {
+	p.Lock()
+	if p.currentDoc.currentPage != nil {
 		// Unload the current page.
-		C.FPDF_ClosePage(d.page)
-		d.page = nil
-		d.currentPage = nil
+		C.FPDF_ClosePage(p.currentDoc.page)
+		p.currentDoc.page = nil
+		p.currentDoc.currentPage = nil
 	}
 
-	pageObject := C.FPDF_LoadPage(d.doc, C.int(page))
-	d.page = pageObject
-	d.currentPage = &page
-	mutex.Unlock()
+	pageObject := C.FPDF_LoadPage(p.currentDoc.doc, C.int(page))
+	p.currentDoc.page = pageObject
+	p.currentDoc.currentPage = &page
+	p.Unlock()
 
 	return
 }

--- a/pdfium/internal/subprocess/render.go
+++ b/pdfium/internal/subprocess/render.go
@@ -7,12 +7,13 @@ import "C"
 
 import (
 	"errors"
-	"github.com/klippa-app/go-pdfium/pdfium/requests"
-	"github.com/klippa-app/go-pdfium/pdfium/responses"
 	"image"
 	"image/color"
 	"math"
 	"unsafe"
+
+	"github.com/klippa-app/go-pdfium/pdfium/requests"
+	"github.com/klippa-app/go-pdfium/pdfium/responses"
 )
 
 // getPageSize returns the pixel size of a page given the pdfium page object DPI.
@@ -35,7 +36,7 @@ func (p *Pdfium) GetPageSize(request *requests.GetPageSize) (*responses.GetPageS
 	p.loadPage(request.Page)
 	widthInPoints, heightInPoints := p.getPageSize()
 	return &responses.GetPageSize{
-		Width: widthInPoints,
+		Width:  widthInPoints,
 		Height: heightInPoints,
 	}, nil
 }
@@ -51,12 +52,12 @@ func (p *Pdfium) GetPageSizeInPixels(request *requests.GetPageSizeInPixels) (*re
 		Page: request.Page,
 	})
 
-	if err != nil{
+	if err != nil {
 		return nil, err
 	}
 
 	return &responses.GetPageSizeInPixels{
-		Width: int(math.Ceil(pageSize.Width * scale)),
+		Width:  int(math.Ceil(pageSize.Width * scale)),
 		Height: int(math.Ceil(pageSize.Height * scale)),
 	}, nil
 }
@@ -69,7 +70,7 @@ func (p *Pdfium) RenderPageInDPI(request *requests.RenderPageInDPI) (*responses.
 
 	pixelSize, err := p.GetPageSizeInPixels(&requests.GetPageSizeInPixels{
 		Page: request.Page,
-		DPI: request.DPI,
+		DPI:  request.DPI,
 	})
 	if err != nil {
 		return nil, err

--- a/pdfium/internal/subprocess/render.go
+++ b/pdfium/internal/subprocess/render.go
@@ -6,6 +6,9 @@ package subprocess
 import "C"
 
 import (
+	"errors"
+	"github.com/klippa-app/go-pdfium/pdfium/requests"
+	"github.com/klippa-app/go-pdfium/pdfium/responses"
 	"image"
 	"image/color"
 	"math"
@@ -13,76 +16,122 @@ import (
 )
 
 // getPageSize returns the pixel size of a page given the pdfium page object DPI.
-func (d *Document) getPageSize() (float64, float64) {
-	mutex.Lock()
-	imgWidth := C.FPDF_GetPageWidth(d.page)
-	imgHeight := C.FPDF_GetPageHeight(d.page)
-	mutex.Unlock()
+func (p *Pdfium) getPageSize() (float64, float64) {
+	p.Lock()
+	imgWidth := C.FPDF_GetPageWidth(p.currentDoc.page)
+	imgHeight := C.FPDF_GetPageHeight(p.currentDoc.page)
+	p.Unlock()
 
 	return float64(imgWidth), float64(imgHeight)
 }
 
 // GetPageSize returns the page size in points
 // One point is 1/72 inch (around 0.3528 mm)
-func (d *Document) GetPageSize(page int) (float64, float64) {
-	d.loadPage(page)
-	return d.getPageSize()
+func (p *Pdfium) GetPageSize(request *requests.GetPageSize) (*responses.GetPageSize, error) {
+	if p.currentDoc == nil {
+		return nil, errors.New("no current document")
+	}
+
+	p.loadPage(request.Page)
+	widthInPoints, heightInPoints := p.getPageSize()
+	return &responses.GetPageSize{
+		Width: widthInPoints,
+		Height: heightInPoints,
+	}, nil
 }
 
 // GetPageSizeInPixels returns the pixel size of a page given the page number and the DPI.
-func (d *Document) GetPageSizeInPixels(page int, dpi int) (int, int) {
-	scale := float64(dpi) / 72.0
-	widthInPoints, heightInPoints := d.GetPageSize(page)
+func (p *Pdfium) GetPageSizeInPixels(request *requests.GetPageSizeInPixels) (*responses.GetPageSizeInPixels, error) {
+	if p.currentDoc == nil {
+		return nil, errors.New("no current document")
+	}
 
-	return int(math.Ceil(widthInPoints * scale)), int(math.Ceil(heightInPoints * scale))
+	scale := float64(request.DPI) / 72.0
+	pageSize, err := p.GetPageSize(&requests.GetPageSize{
+		Page: request.Page,
+	})
+
+	if err != nil{
+		return nil, err
+	}
+
+	return &responses.GetPageSizeInPixels{
+		Width: int(math.Ceil(pageSize.Width * scale)),
+		Height: int(math.Ceil(pageSize.Height * scale)),
+	}, nil
 }
 
-// renderPageInDPI renders a specific page in a specific dpi, the result is an image.
-func (d *Document) renderPageInDPI(page, dpi int) *image.RGBA {
-	width, height := d.GetPageSizeInPixels(page, dpi)
-	return d.renderPage(page, width, height)
+// RenderPageInDPI renders a specific page in a specific dpi, the result is an image.
+func (p *Pdfium) RenderPageInDPI(request *requests.RenderPageInDPI) (*responses.RenderPage, error) {
+	if p.currentDoc == nil {
+		return nil, errors.New("no current document")
+	}
+
+	pixelSize, err := p.GetPageSizeInPixels(&requests.GetPageSizeInPixels{
+		Page: request.Page,
+		DPI: request.DPI,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &responses.RenderPage{
+		Image: p.renderPage(request.Page, pixelSize.Width, pixelSize.Height),
+	}, nil
 }
 
-// renderPageInPixels renders a specific page in a specific pixel size, the result is an image.
+// RenderPageInPixels renders a specific page in a specific pixel size, the result is an image.
 // The given resolution is a maximum, we automatically calculate either the width or the height
 // to make sure it stays withing the maximum resolution.
-func (d *Document) renderPageInPixels(page, width, height int) *image.RGBA {
-	widthInPoints, heightInPoints := d.GetPageSize(page)
+func (p *Pdfium) RenderPageInPixels(request *requests.RenderPageInPixels) (*responses.RenderPage, error) {
+	if p.currentDoc == nil {
+		return nil, errors.New("no current document")
+	}
 
-	targetWidth := float64(width)
-	targetHeight := float64(height)
-	if height == 0 {
+	pageSize, err := p.GetPageSize(&requests.GetPageSize{
+		Page: request.Page,
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	targetWidth := float64(request.Width)
+	targetHeight := float64(request.Height)
+	if request.Height == 0 {
 		// Height not set, add ratio to height.
-		ratio := heightInPoints / widthInPoints
+		ratio := pageSize.Height / pageSize.Width
 		targetHeight = targetWidth * ratio
-	} else if width == 0 {
+	} else if request.Width == 0 {
 		// Width not set, add ratio to width.
-		ratio := widthInPoints / heightInPoints
+		ratio := pageSize.Width / pageSize.Height
 		targetWidth = targetHeight * ratio
 	} else {
 		// Both values set, automatically pick the correct ratio.
-		ratio := heightInPoints / widthInPoints
-		if (targetWidth * ratio) < float64(height) {
+		ratio := pageSize.Height / pageSize.Width
+		if (targetWidth * ratio) < float64(request.Height) {
 			targetHeight = targetWidth * ratio
 		} else {
-			ratio := widthInPoints / heightInPoints
-			if (targetHeight * ratio) < float64(width) {
+			ratio := pageSize.Width / pageSize.Height
+			if (targetHeight * ratio) < float64(request.Width) {
 				targetWidth = targetHeight * ratio
 			}
 		}
 	}
 
-	width = int(math.Ceil(targetWidth))
-	height = int(math.Ceil(targetHeight))
+	request.Width = int(math.Ceil(targetWidth))
+	request.Height = int(math.Ceil(targetHeight))
 
-	return d.renderPage(page, width, height)
+	return &responses.RenderPage{
+		Image: p.renderPage(request.Page, request.Width, request.Height),
+	}, nil
 }
 
 // RenderPage renders a specific page in a specific dpi, the result is an image.
-func (d *Document) renderPage(page, width, height int) *image.RGBA {
-	d.loadPage(page)
-	mutex.Lock()
-	alpha := C.FPDFPage_HasTransparency(d.page)
+func (p *Pdfium) renderPage(page, width, height int) *image.RGBA {
+	p.loadPage(page)
+	p.Lock()
+	alpha := C.FPDFPage_HasTransparency(p.currentDoc.page)
 	bitmap := C.FPDFBitmap_Create(C.int(width), C.int(height), alpha)
 
 	fillColor := 4294967295
@@ -91,12 +140,12 @@ func (d *Document) renderPage(page, width, height int) *image.RGBA {
 	}
 
 	C.FPDFBitmap_FillRect(bitmap, 0, 0, C.int(width), C.int(height), C.ulong(fillColor))
-	C.FPDF_RenderPageBitmap(bitmap, d.page, 0, 0, C.int(width), C.int(height), 0, C.FPDF_ANNOT)
+	C.FPDF_RenderPageBitmap(bitmap, p.currentDoc.page, 0, 0, C.int(width), C.int(height), 0, C.FPDF_ANNOT)
 
-	p := C.FPDFBitmap_GetBuffer(bitmap)
+	b := C.FPDFBitmap_GetBuffer(bitmap)
 	img := image.NewRGBA(image.Rect(0, 0, width, height))
 	img.Stride = int(C.FPDFBitmap_GetStride(bitmap))
-	mutex.Unlock()
+	p.Unlock()
 
 	// This takes a bit of time and I *think* we can do this without the lock
 	// @todo: figure out if we can do this better/faster.
@@ -104,16 +153,16 @@ func (d *Document) renderPage(page, width, height int) *image.RGBA {
 	for y := 0; y < height; y++ {
 		for x := 0; x < width; x++ {
 			for i := range bgra {
-				bgra[i] = *((*byte)(p))
-				p = unsafe.Pointer(uintptr(p) + 1)
+				bgra[i] = *((*byte)(b))
+				b = unsafe.Pointer(uintptr(b) + 1)
 			}
 			pixelColor := color.RGBA{B: bgra[0], G: bgra[1], R: bgra[2], A: bgra[3]}
 			img.SetRGBA(x, y, pixelColor)
 		}
 	}
-	mutex.Lock()
+	p.Lock()
 	C.FPDFBitmap_Destroy(bitmap)
-	mutex.Unlock()
+	p.Unlock()
 
 	return img
 }

--- a/pdfium/internal/subprocess/render.go
+++ b/pdfium/internal/subprocess/render.go
@@ -19,8 +19,8 @@ import (
 // getPageSize returns the pixel size of a page given the pdfium page object DPI.
 func (p *Pdfium) getPageSize() (float64, float64) {
 	p.Lock()
-	imgWidth := C.FPDF_GetPageWidth(p.currentDoc.page)
-	imgHeight := C.FPDF_GetPageHeight(p.currentDoc.page)
+	imgWidth := C.FPDF_GetPageWidth(p.currentPage)
+	imgHeight := C.FPDF_GetPageHeight(p.currentPage)
 	p.Unlock()
 
 	return float64(imgWidth), float64(imgHeight)
@@ -132,7 +132,7 @@ func (p *Pdfium) RenderPageInPixels(request *requests.RenderPageInPixels) (*resp
 func (p *Pdfium) renderPage(page, width, height int) *image.RGBA {
 	p.loadPage(page)
 	p.Lock()
-	alpha := C.FPDFPage_HasTransparency(p.currentDoc.page)
+	alpha := C.FPDFPage_HasTransparency(p.currentPage)
 	bitmap := C.FPDFBitmap_Create(C.int(width), C.int(height), alpha)
 
 	fillColor := 4294967295
@@ -141,7 +141,7 @@ func (p *Pdfium) renderPage(page, width, height int) *image.RGBA {
 	}
 
 	C.FPDFBitmap_FillRect(bitmap, 0, 0, C.int(width), C.int(height), C.ulong(fillColor))
-	C.FPDF_RenderPageBitmap(bitmap, p.currentDoc.page, 0, 0, C.int(width), C.int(height), 0, C.FPDF_ANNOT)
+	C.FPDF_RenderPageBitmap(bitmap, p.currentPage, 0, 0, C.int(width), C.int(height), 0, C.FPDF_ANNOT)
 
 	b := C.FPDFBitmap_GetBuffer(bitmap)
 	img := image.NewRGBA(image.Rect(0, 0, width, height))

--- a/pdfium/internal/subprocess/subprocess.go
+++ b/pdfium/internal/subprocess/subprocess.go
@@ -21,21 +21,16 @@ func init() {
 	InitLibrary()
 }
 
-// Document is good
-type Document struct {
-	// C data
-	doc  C.FPDF_DOCUMENT
-	page C.FPDF_PAGE
-
-	currentPage *int    // Remember which page is currently loaded in the page variable.
-	data        *[]byte // Keep a reference to the data otherwise weird stuff happens
-}
-
 // Here is the real implementation of Pdfium
 type Pdfium struct {
-	logger     hclog.Logger
-	currentDoc *Document
-	mutex      sync.Mutex
+	// C data
+	currentDoc  C.FPDF_DOCUMENT
+	currentPage C.FPDF_PAGE
+
+	logger            hclog.Logger
+	mutex             sync.Mutex
+	currentPageNumber *int    // Remember which page is currently loaded in the page variable.
+	data              *[]byte // Keep a reference to the data otherwise weird stuff happens
 }
 
 func (p *Pdfium) Ping() (string, error) {
@@ -83,8 +78,8 @@ func (p *Pdfium) OpenDocument(request *requests.OpenDocument) error {
 		return errors.New(errMsg)
 	}
 
-	p.currentDoc = &Document{doc: doc, data: request.File}
-
+	p.currentDoc = doc
+	p.data = request.File
 	return nil
 }
 

--- a/pdfium/internal/subprocess/subprocess.go
+++ b/pdfium/internal/subprocess/subprocess.go
@@ -123,6 +123,7 @@ var handshakeConfig = plugin.HandshakeConfig{
 }
 
 var globalMutex = &sync.Mutex{}
+
 func InitLibrary() {
 	globalMutex.Lock()
 	C.FPDF_InitLibrary()

--- a/pdfium/internal/subprocess/subprocess.go
+++ b/pdfium/internal/subprocess/subprocess.go
@@ -7,8 +7,11 @@ import "C"
 import (
 	"errors"
 	"os"
+	"sync"
+	"unsafe"
 
 	"github.com/klippa-app/go-pdfium/pdfium/internal/commons"
+	"github.com/klippa-app/go-pdfium/pdfium/requests"
 
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-plugin"
@@ -18,113 +21,71 @@ func init() {
 	InitLibrary()
 }
 
+// Document is good
+type Document struct {
+	// C data
+	doc  C.FPDF_DOCUMENT
+	page C.FPDF_PAGE
+
+	currentPage *int    // Remember which page is currently loaded in the page variable.
+	data        *[]byte // Keep a reference to the data otherwise weird stuff happens
+}
+
 // Here is the real implementation of Pdfium
 type Pdfium struct {
-	logger hclog.Logger
+	logger     hclog.Logger
+	currentDoc *Document
+	mutex      sync.Mutex
 }
 
 func (p *Pdfium) Ping() (string, error) {
 	return "Pong", nil
 }
 
-func (p *Pdfium) OpenDocument(request *commons.OpenDocumentRequest) error {
-	newDocument, err := NewDocument(request.File)
-	if err != nil {
-		return err
+func (p *Pdfium) Lock() {
+	p.mutex.Lock()
+}
+
+func (p *Pdfium) Unlock() {
+	p.mutex.Unlock()
+}
+
+func (p *Pdfium) OpenDocument(request *requests.OpenDocument) error {
+	p.Lock()
+	defer p.Unlock()
+	doc := C.FPDF_LoadMemDocument(
+		unsafe.Pointer(&((*request.File)[0])),
+		C.int(len(*request.File)),
+		nil)
+
+	if doc == nil {
+		var errMsg string
+
+		errorCode := C.FPDF_GetLastError()
+		switch errorCode {
+		case C.FPDF_ERR_SUCCESS:
+			errMsg = "Success"
+		case C.FPDF_ERR_UNKNOWN:
+			errMsg = "Unknown error"
+		case C.FPDF_ERR_FILE:
+			errMsg = "Unable to read file"
+		case C.FPDF_ERR_FORMAT:
+			errMsg = "Incorrect format"
+		case C.FPDF_ERR_PASSWORD:
+			errMsg = "Invalid password"
+		case C.FPDF_ERR_SECURITY:
+			errMsg = "Invalid encryption"
+		case C.FPDF_ERR_PAGE:
+			errMsg = "Incorrect page"
+		default:
+			errMsg = "Unexpected error"
+		}
+		return errors.New(errMsg)
 	}
 
-	currentDoc = newDocument
+	p.currentDoc = &Document{doc: doc, data: request.File}
 
 	return nil
-}
-
-func (p *Pdfium) Close() error {
-	if currentDoc == nil {
-		return errors.New("no current document")
-	}
-
-	currentDoc.Close()
-	currentDoc = nil
-
-	return nil
-}
-
-func (p *Pdfium) GetPageText(request *commons.GetPageTextRequest) (commons.GetPageTextResponse, error) {
-	if currentDoc == nil {
-		return commons.GetPageTextResponse{}, errors.New("no current document")
-	}
-	text := currentDoc.GetPageText(request.Page)
-	return commons.GetPageTextResponse{
-		Text: &text,
-	}, nil
-}
-
-func (p *Pdfium) GetPageTextStructured(request *commons.GetPageTextStructuredRequest) (commons.GetPageTextStructuredResponse, error) {
-	if currentDoc == nil {
-		return commons.GetPageTextStructuredResponse{}, errors.New("no current document")
-	}
-	structuredText := currentDoc.GetPageTextStructured(request.Page, request.Mode)
-	return *structuredText, nil
-}
-
-func (p *Pdfium) GetPageSize(request *commons.GetPageSizeRequest) (commons.GetPageSizeResponse, error) {
-	if currentDoc == nil {
-		return commons.GetPageSizeResponse{}, errors.New("no current document")
-	}
-	width, height := currentDoc.GetPageSize(request.Page)
-	return commons.GetPageSizeResponse{
-		Width:  width,
-		Height: height,
-	}, nil
-}
-
-func (p *Pdfium) GetPageSizeInPixels(request *commons.GetPageSizeInPixelsRequest) (commons.GetPageSizeInPixelsResponse, error) {
-	if currentDoc == nil {
-		return commons.GetPageSizeInPixelsResponse{}, errors.New("no current document")
-	}
-	width, height := currentDoc.GetPageSizeInPixels(request.Page, request.DPI)
-	return commons.GetPageSizeInPixelsResponse{
-		Width:  width,
-		Height: height,
-	}, nil
-}
-
-func (p *Pdfium) RenderPageInDPI(request *commons.RenderPageInDPIRequest) (commons.RenderPageResponse, error) {
-	if currentDoc == nil {
-		return commons.RenderPageResponse{}, errors.New("no current document")
-	}
-
-	if request.DPI == 0 {
-		return commons.RenderPageResponse{}, errors.New("DPI should be given")
-	}
-
-	renderedPage := currentDoc.renderPageInDPI(request.Page, request.DPI)
-	return commons.RenderPageResponse{
-		Image: renderedPage,
-	}, nil
-}
-
-func (p *Pdfium) RenderPageInPixels(request *commons.RenderPageInPixelsRequest) (commons.RenderPageResponse, error) {
-	if currentDoc == nil {
-		return commons.RenderPageResponse{}, errors.New("no current document")
-	}
-
-	if request.Width == 0 && request.Height == 0 {
-		return commons.RenderPageResponse{}, errors.New("either width or height should be given")
-	}
-
-	renderedPage := currentDoc.renderPageInPixels(request.Page, request.Width, request.Height)
-	return commons.RenderPageResponse{
-		Image: renderedPage,
-	}, nil
-}
-
-func (p *Pdfium) GetPageCount() (int, error) {
-	if currentDoc == nil {
-		return 0, errors.New("no current document")
-	}
-	pageCount := currentDoc.GetPageCount()
-	return pageCount, nil
 }
 
 func Main() {
@@ -161,14 +122,15 @@ var handshakeConfig = plugin.HandshakeConfig{
 	MagicCookieValue: "hello",
 }
 
+var globalMutex = &sync.Mutex{}
 func InitLibrary() {
-	mutex.Lock()
+	globalMutex.Lock()
 	C.FPDF_InitLibrary()
-	mutex.Unlock()
+	globalMutex.Unlock()
 }
 
 func DestroyLibrary() {
-	mutex.Lock()
+	globalMutex.Lock()
 	C.FPDF_DestroyLibrary()
-	mutex.Unlock()
+	globalMutex.Unlock()
 }

--- a/pdfium/internal/subprocess/text.go
+++ b/pdfium/internal/subprocess/text.go
@@ -23,7 +23,7 @@ func (p *Pdfium) GetPageText(request *requests.GetPageText) (*responses.GetPageT
 	p.loadPage(request.Page)
 
 	p.Lock()
-	textPage := C.FPDFText_LoadPage(p.currentDoc.page)
+	textPage := C.FPDFText_LoadPage(p.currentPage)
 	charsInPage := int(C.FPDFText_CountChars(textPage))
 	charData := make([]byte, (charsInPage+1)*4) // UTF-8 = Max 4 bytes per char, add 1 for terminator.
 	charsWritten := C.FPDFText_GetText(textPage, C.int(0), C.int(charsInPage), (*C.ushort)(unsafe.Pointer(&charData[0])))
@@ -48,7 +48,7 @@ func (p *Pdfium) GetPageTextStructured(request *requests.GetPageTextStructured) 
 	}
 
 	p.Lock()
-	textPage := C.FPDFText_LoadPage(p.currentDoc.page)
+	textPage := C.FPDFText_LoadPage(p.currentPage)
 	charsInPage := C.FPDFText_CountChars(textPage)
 
 	if request.Mode == "" || request.Mode == requests.GetPageTextStructuredModeChars || request.Mode == requests.GetPageTextStructuredModeBoth {

--- a/pdfium/pdfium.go
+++ b/pdfium/pdfium.go
@@ -4,7 +4,8 @@ import (
 	goctx "context"
 	"errors"
 	"fmt"
-	"image"
+	"github.com/klippa-app/go-pdfium/pdfium/requests"
+	"github.com/klippa-app/go-pdfium/pdfium/responses"
 	"os"
 	"os/exec"
 	"time"
@@ -156,7 +157,7 @@ func NewDocument(file *[]byte) (Document, error) {
 	newDocument := pdfiumDocument{}
 	newDocument.worker = selectedWorker
 
-	err = newDocument.worker.plugin.OpenDocument(&commons.OpenDocumentRequest{File: file})
+	err = newDocument.worker.plugin.OpenDocument(&requests.OpenDocument{File: file})
 	if err != nil {
 		newDocument.Close()
 		return nil, err
@@ -166,13 +167,13 @@ func NewDocument(file *[]byte) (Document, error) {
 }
 
 type Document interface {
-	GetPageCount() (int, error)
-	GetPageText(page int) (*string, error)
-	GetPageTextStructured(page int) (*commons.GetPageTextStructuredResponse, error)
-	RenderPageInDPI(page, dpi int) (*image.RGBA, error)
-	RenderPageInPixels(page, width, height int) (*image.RGBA, error)
-	GetPageSize(page int) (float64, float64, error)
-	GetPageSizeInPixels(page, dpi int) (int, int, error)
+	GetPageCount(request *requests.GetPageCount) (*responses.GetPageCount, error)
+	GetPageText(request *requests.GetPageText) (*responses.GetPageText, error)
+	GetPageTextStructured(request *requests.GetPageTextStructured) (*responses.GetPageTextStructured, error)
+	RenderPageInDPI(request *requests.RenderPageInDPI) (*responses.RenderPage, error)
+	RenderPageInPixels(request *requests.RenderPageInPixels) (*responses.RenderPage, error)
+	GetPageSize(request *requests.GetPageSize) (*responses.GetPageSize, error)
+	GetPageSizeInPixels(request *requests.GetPageSizeInPixels) (*responses.GetPageSizeInPixels, error)
 	Close()
 }
 
@@ -180,74 +181,32 @@ type pdfiumDocument struct {
 	worker *worker
 }
 
-func (d *pdfiumDocument) GetPageCount() (int, error) {
-	return d.worker.plugin.GetPageCount()
+func (d *pdfiumDocument) GetPageCount(request *requests.GetPageCount) (*responses.GetPageCount, error) {
+	return d.worker.plugin.GetPageCount(request)
 }
 
-func (d *pdfiumDocument) GetPageText(page int) (*string, error) {
-	pageText, err := d.worker.plugin.GetPageText(&commons.GetPageTextRequest{Page: page})
-	if err != nil {
-		return nil, err
-	}
-	if pageText.Text == nil {
-		return nil, errors.New("did not receive text")
-	}
-	return pageText.Text, err
+func (d *pdfiumDocument) GetPageText(request *requests.GetPageText) (*responses.GetPageText, error) {
+	return d.worker.plugin.GetPageText(request)
 }
 
-func (d *pdfiumDocument) GetPageTextStructured(page int) (*commons.GetPageTextStructuredResponse, error) {
-	pageText, err := d.worker.plugin.GetPageTextStructured(&commons.GetPageTextStructuredRequest{Page: page})
-	if err != nil {
-		return nil, err
-	}
-
-	if pageText.Chars == nil && pageText.Rects == nil {
-		return nil, errors.New("did not receive structured text")
-	}
-	return &commons.GetPageTextStructuredResponse{
-		Chars: pageText.Chars,
-		Rects: pageText.Rects,
-	}, err
+func (d *pdfiumDocument) GetPageTextStructured(request *requests.GetPageTextStructured) (*responses.GetPageTextStructured, error) {
+	return d.worker.plugin.GetPageTextStructured(request)
 }
 
-func (d *pdfiumDocument) RenderPageInDPI(page, dpi int) (*image.RGBA, error) {
-	renderedPage, err := d.worker.plugin.RenderPageInDPI(&commons.RenderPageInDPIRequest{Page: page, DPI: dpi})
-	if err != nil {
-		return nil, err
-	}
-	if renderedPage.Image == nil {
-		return nil, errors.New("did not receive an image")
-	}
-	return renderedPage.Image, err
+func (d *pdfiumDocument) RenderPageInDPI(request *requests.RenderPageInDPI) (*responses.RenderPage, error) {
+	return d.worker.plugin.RenderPageInDPI(request)
 }
 
-func (d *pdfiumDocument) RenderPageInPixels(page, width, height int) (*image.RGBA, error) {
-	renderedPage, err := d.worker.plugin.RenderPageInPixels(&commons.RenderPageInPixelsRequest{Page: page, Width: width, Height: height})
-	if err != nil {
-		return nil, err
-	}
-	if renderedPage.Image == nil {
-		return nil, errors.New("did not receive an image")
-	}
-	return renderedPage.Image, err
+func (d *pdfiumDocument) RenderPageInPixels(request *requests.RenderPageInPixels) (*responses.RenderPage, error) {
+	return d.worker.plugin.RenderPageInPixels(request)
 }
 
-func (d *pdfiumDocument) GetPageSize(page int) (float64, float64, error) {
-	pageSize, err := d.worker.plugin.GetPageSize(&commons.GetPageSizeRequest{Page: page})
-	if err != nil {
-		return 0, 0, err
-	}
-
-	return pageSize.Width, pageSize.Height, nil
+func (d *pdfiumDocument) GetPageSize(request *requests.GetPageSize) (*responses.GetPageSize, error) {
+	return d.worker.plugin.GetPageSize(request)
 }
 
-func (d *pdfiumDocument) GetPageSizeInPixels(page, dpi int) (int, int, error) {
-	pageSize, err := d.worker.plugin.GetPageSizeInPixels(&commons.GetPageSizeInPixelsRequest{Page: page, DPI: dpi})
-	if err != nil {
-		return 0, 0, err
-	}
-
-	return pageSize.Width, pageSize.Height, nil
+func (d *pdfiumDocument) GetPageSizeInPixels(request *requests.GetPageSizeInPixels) (*responses.GetPageSizeInPixels, error) {
+	return d.worker.plugin.GetPageSizeInPixels(request)
 }
 
 func (d *pdfiumDocument) Close() {

--- a/pdfium/requests/requests.go
+++ b/pdfium/requests/requests.go
@@ -4,7 +4,7 @@ type OpenDocument struct {
 	File *[]byte // A reference to the file data.
 }
 
-type GetPageCount struct {}
+type GetPageCount struct{}
 
 type RenderPageInDPI struct {
 	Page int // The page number (0-index based).

--- a/pdfium/requests/requests.go
+++ b/pdfium/requests/requests.go
@@ -1,0 +1,60 @@
+package requests
+
+type OpenDocument struct {
+	File *[]byte // A reference to the file data.
+}
+
+type GetPageCount struct {}
+
+type RenderPageInDPI struct {
+	Page int // The page number (0-index based).
+	DPI  int // The DPI to render the page in.
+}
+
+type RenderPageInPixels struct {
+	Page   int // The page number (0-index based).
+	Width  int // The maximum width of the image.
+	Height int // The maximum height of the image.
+}
+
+type GetPageSize struct {
+	Page int // The page number (0-index based).
+}
+
+type GetPageSizeInPixels struct {
+	Page int // The page number (0-index based).
+	DPI  int // The DPI to calculate the size for.
+}
+
+type GetPageText struct {
+	Page int // The page number (0-index based).
+}
+
+type GetPageTextStructured struct {
+	Page           int                                 // The page number (0-index based).
+	Mode           GetPageTextStructuredMode           // The mode to get structured text for.
+	PixelPositions GetPageTextStructuredPixelPositions // Pixel position calculation settings.
+}
+
+type GetPageTextStructuredMode string
+
+const (
+	GetPageTextStructuredModeChars GetPageTextStructuredMode = "char" // Only get every separate char
+	GetPageTextStructuredModeRects GetPageTextStructuredMode = "rect" // Get char rects, strings on the same line with the same font settings.
+	GetPageTextStructuredModeBoth  GetPageTextStructuredMode = "both" // Get both rects and chars.
+)
+
+type GetPageTextStructuredPixelPositions struct {
+	// Whether to calculate from points to pixel.
+	// Useful if you used RenderPageInDPI or RenderPageInPixels.
+	Calculate bool
+
+	// If rendered in a specific DPI, give the DPI.
+	// Useful if you used RenderPageInDPI.
+	DPI int
+
+	// If rendered with a specific resolution, give the resolution.
+	// Useful if you used RenderPageInPixels.
+	Width  int
+	Height int
+}

--- a/pdfium/responses/responses.go
+++ b/pdfium/responses/responses.go
@@ -1,0 +1,50 @@
+package responses
+
+import "image"
+
+type GetPageCount struct {
+	PageCount int
+}
+
+type RenderPage struct {
+	Image *image.RGBA
+}
+
+type GetPageSize struct {
+	Width  float64
+	Height float64
+}
+
+type GetPageSizeInPixels struct {
+	Width  int
+	Height int
+}
+
+type GetPageText struct {
+	Text string
+}
+
+type CharPosition struct {
+	Left   float64
+	Top    float64
+	Right  float64
+	Bottom float64
+}
+
+type GetPageTextStructuredChar struct {
+	Text          string
+	Angle         float64
+	PointPosition CharPosition
+	PixelPosition *CharPosition
+}
+
+type GetPageTextStructuredRect struct {
+	Text          string
+	PointPosition CharPosition
+	PixelPosition *CharPosition
+}
+
+type GetPageTextStructured struct {
+	Chars []*GetPageTextStructuredChar
+	Rects []*GetPageTextStructuredRect
+}


### PR DESCRIPTION
- Pass everything as pointers
- Less conversion between data, everything uses requests/responses now, which makes adding new methods easier
- Remove glue layer between `Pdfium` and `Document`
- Move requests/responses objects outside internal and in separate packages so they can be used externally