### PR TITLE
Calculate ratio between pixels and points

### DIFF
--- a/pdfium/internal/subprocess/text.go
+++ b/pdfium/internal/subprocess/text.go
@@ -8,6 +8,7 @@ import "C"
 import (
 	"bytes"
 	"errors"
+	"math"
 	"unsafe"
 
 	"github.com/klippa-app/go-pdfium/pdfium/requests"
@@ -138,9 +139,9 @@ func convertPointPositions(pixelPositions requests.GetPageTextStructuredPixelPos
 	}
 
 	return &responses.CharPosition{
-		Left:   pointPositions.Left * ratio,
-		Top:    pointPositions.Top * ratio,
-		Right:  pointPositions.Right * ratio,
-		Bottom: pointPositions.Bottom * ratio,
+		Left:   math.Round(pointPositions.Left * ratio),
+		Top:    math.Round(pointPositions.Top * ratio),
+		Right:  math.Round(pointPositions.Right * ratio),
+		Bottom: math.Round(pointPositions.Bottom * ratio),
 	}
 }

--- a/pdfium/responses/responses.go
+++ b/pdfium/responses/responses.go
@@ -7,7 +7,8 @@ type GetPageCount struct {
 }
 
 type RenderPage struct {
-	Image *image.RGBA
+	Image             *image.RGBA
+	PointToPixelRatio float64
 }
 
 type GetPageSize struct {
@@ -16,8 +17,9 @@ type GetPageSize struct {
 }
 
 type GetPageSizeInPixels struct {
-	Width  int
-	Height int
+	Width             int
+	Height            int
+	PointToPixelRatio float64
 }
 
 type GetPageText struct {
@@ -45,6 +47,7 @@ type GetPageTextStructuredRect struct {
 }
 
 type GetPageTextStructured struct {
-	Chars []*GetPageTextStructuredChar
-	Rects []*GetPageTextStructuredRect
+	Chars             []*GetPageTextStructuredChar
+	Rects             []*GetPageTextStructuredRect
+	PointToPixelRatio float64
 }


### PR DESCRIPTION
This pull request adds:
- Returning the point to pixel ratio in page size, renders and text extract
- Automatically add information about text positions in pixel locations 