### PR TITLE
Fix background on JPG rendering

### DIFF
--- a/internal/implementation/render.go
+++ b/internal/implementation/render.go
@@ -366,7 +366,7 @@ func (p *PdfiumImplementation) renderPage(bitmap C.FPDF_BITMAP, page requests.Pa
 	hasTransparency := int(alpha) == 1
 
 	// When the page has transparency, fill with black, not white.
-	if int(alpha) == 1 {
+	if hasTransparency {
 		// Black
 		fillColor = 0x00000000
 	}

--- a/internal/implementation/render.go
+++ b/internal/implementation/render.go
@@ -489,10 +489,10 @@ func (p *PdfiumImplementation) RenderToFile(request *requests.RenderToFile) (*re
 		// rendered PDF will look the same as in a PDF viewer, those generally
 		// have a white background on the page viewer.
 		if hasTransparency {
-			dst := image.NewRGBA(renderedImage.Bounds())
-			draw.Draw(dst, dst.Bounds(), image.NewUniform(color.White), image.Point{}, draw.Src)
-			draw.Draw(dst, dst.Bounds(), renderedImage, renderedImage.Bounds().Min, draw.Over)
-			renderedImage = dst
+			imageWithWhiteBackground := image.NewRGBA(renderedImage.Bounds())
+			draw.Draw(imageWithWhiteBackground, imageWithWhiteBackground.Bounds(), image.NewUniform(color.White), image.Point{}, draw.Src)
+			draw.Draw(imageWithWhiteBackground, imageWithWhiteBackground.Bounds(), renderedImage, renderedImage.Bounds().Min, draw.Over)
+			renderedImage = imageWithWhiteBackground
 		}
 
 		for {

--- a/responses/render.go
+++ b/responses/render.go
@@ -10,6 +10,7 @@ type RenderPage struct {
 	Image             *image.RGBA // The rendered image.
 	Width             int         // The width of the rendered image.
 	Height            int         // The height of the rendered image.
+	HasTransparency   bool        // Whether the page has transparency.
 }
 
 type RenderPagesPage struct {
@@ -19,6 +20,7 @@ type RenderPagesPage struct {
 	Height            int     // The height of the rendered page inside the image.
 	X                 int     // The X start position of this page inside the image.
 	Y                 int     // The Y start position of this page inside the image.
+	HasTransparency   bool    // Whether the page has transparency.
 }
 
 type RenderPages struct {


### PR DESCRIPTION
When rendering pages that have transparency and then saving them as JPG in Go, it will convert the alpha channel to black, which causes transparent parts of the page to become invisible. 

This fix will create a white background for pages that contain transparency, to make sure that text is readable when rendering as JPG. This emulates how PDF viewers behave, by having a white background under the page in PDF viewers. 