### PR TITLE
Fix the WebAssembly build

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -100,6 +100,7 @@ jobs:
         go: [ "1.20", "1.21", "1.22" ]
     env:
       PDFIUM_EXPERIMENTAL_GO_VERSION: "1.22"
+      CGO_ENABLED: "0"
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/internal/implementation_webassembly/fpdf_annot.go
+++ b/internal/implementation_webassembly/fpdf_annot.go
@@ -1,6 +1,5 @@
 package implementation_webassembly
 
-import "C"
 import (
 	"errors"
 	"unsafe"


### PR DESCRIPTION
Accidentally a `import "C"` was added to the WebAssembly implementation. When you then have no CGO available in your environment, the build fails. I have also added some extra steps to catch this in the CI process next time.

Fixes #169