### PR TITLE
Fix experimental FPDFText_HasUnicodeMapError implement.

### DIFF
--- a/internal/implementation_cgo/fpdf_text_experimental.go
+++ b/internal/implementation_cgo/fpdf_text_experimental.go
@@ -304,7 +304,7 @@ func (p *PdfiumImplementation) FPDFText_HasUnicodeMapError(request *requests.FPD
 		return nil, err
 	}
 
-	hasUnicodeMapError := C.FPDFText_IsGenerated(textPageHandle.handle, C.int(request.Index))
+	hasUnicodeMapError := C.FPDFText_HasUnicodeMapError(textPageHandle.handle, C.int(request.Index))
 	if int(hasUnicodeMapError) == -1 {
 		return nil, errors.New("could not get whether text has a unicode map error")
 	}


### PR DESCRIPTION
Fix the FPDFText_HasUnicodeMapError method was not call the right pdfium C API.