### PR TITLE
Fix the text extraction wrong after special characters

### DIFF
--- a/internal/implementation_cgo/text.go
+++ b/internal/implementation_cgo/text.go
@@ -61,18 +61,18 @@ func (p *PdfiumImplementation) GetPageText(request *requests.GetPageText) (*resp
 
 	textPage := C.FPDFText_LoadPage(pageHandle.handle)
 	charsInPage := int(C.FPDFText_CountChars(textPage))
-	charData := make([]byte, (charsInPage+1)*2) // UTF16-LE max 2 bytes per char, add 1 char for terminator.
-	charsWritten := C.FPDFText_GetText(textPage, C.int(0), C.int(charsInPage), (*C.ushort)(unsafe.Pointer(&charData[0])))
-	C.FPDFText_ClosePage(textPage)
-
-	transformedText, err := p.transformUTF16LEToUTF8(charData[0 : charsWritten*2])
-	if err != nil {
-		return nil, err
+	charData := make([]rune, 0, charsInPage)
+	for i := 0; i < charsInPage; i++ {
+		uniChar := C.FPDFText_GetUnicode(textPage, C.int(i))
+		if uniChar != 0 {
+			charData = append(charData, rune(uniChar))
+		}
 	}
+	C.FPDFText_ClosePage(textPage)
 
 	return &responses.GetPageText{
 		Page: pageHandle.index,
-		Text: transformedText,
+		Text: string(charData),
 	}, nil
 }
 


### PR DESCRIPTION
the FPDFText_CountChars function returned text char count in this page, 
and the FPDFText_GetCharBox function returned text char box in this page, the `text_index` argument means `character index`
but the FPDFText_GetText function returned a sub-string of page text, the `text_index` argument means `UCS16 code index`!
so, if some character need two(or more) UCS16 codes, then the text char was mistach the text char box after it!
I came across this case, and found a solution: use the FPDFText_GetUnicode function instead FPDFText_GetText.

the FPDFText_GetUnicode function returned text char with unicode, the `text_index` argument means `character index` too.

Finally, I feel that pdfium may always assume that UTF16 takes only 2 bytes per character :(
