### PR TITLE
Fix: [FPDFPageObj_SetLineCap should call SetLineCap, not SetLineJoin

### DIFF
--- a/internal/implementation_cgo/fpdf_edit.go
+++ b/internal/implementation_cgo/fpdf_edit.go
@@ -906,7 +906,7 @@ func (p *PdfiumImplementation) FPDFPageObj_SetLineCap(request *requests.FPDFPage
 		return nil, err
 	}
 
-	success := C.FPDFPageObj_SetLineJoin(pageObjectHandle.handle, C.int(request.LineCap))
+	success := C.FPDFPageObj_SetLineCap(pageObjectHandle.handle, C.int(request.LineCap))
 	if int(success) == 0 {
 		return nil, errors.New("could not set page object line cap")
 	}


### PR DESCRIPTION
Here I see this bug
<img width="1157" height="416" alt="image" src="https://github.com/user-attachments/assets/216b2944-391b-46e3-a1e4-7ee831c2f40b" />

So I file this bug fix, hah.
