### PR TITLE
Add dll export to the callback functions.

### DIFF
--- a/internal/implementation_cgo/fpdf_dataavail.go
+++ b/internal/implementation_cgo/fpdf_dataavail.go
@@ -4,11 +4,12 @@ package implementation_cgo
 #cgo pkg-config: pdfium
 #include "fpdf_dataavail.h"
 #include <stdlib.h>
+#include "go_pdfium_cgo_export.h"
 
-extern int go_dataavail_is_data_avail_cb(struct _FX_FILEAVAIL *me, size_t offset, size_t size);
-extern void go_dataavail_add_segment_cb(struct _FX_DOWNLOADHINTS *me, size_t offset, size_t size);
+extern GO_FPDF_EXPORT int GO_FPDF_CALLCONV go_dataavail_is_data_avail_cb(struct _FX_FILEAVAIL *me, size_t offset, size_t size);
+extern GO_FPDF_EXPORT void GO_FPDF_CALLCONV go_dataavail_add_segment_cb(struct _FX_DOWNLOADHINTS *me, size_t offset, size_t size);
 
-extern int go_read_seeker_cb(void *param, unsigned long position, unsigned char *pBuf, unsigned long size);
+extern GO_FPDF_EXPORT int GO_FPDF_CALLCONV go_read_seeker_cb(void *param, unsigned long position, unsigned char *pBuf, unsigned long size);
 
 static inline void FPDF_FX_FILEAVAIL_CB(FX_FILEAVAIL *p) {
 	p->IsDataAvail = &go_dataavail_is_data_avail_cb;

--- a/internal/implementation_cgo/fpdf_ext.go
+++ b/internal/implementation_cgo/fpdf_ext.go
@@ -5,13 +5,16 @@ package implementation_cgo
 #include "fpdf_ext.h"
 #include <time.h>
 #include <stdio.h>
+#include "go_pdfium_cgo_export.h"
 
-extern void go_un_sp_obj_cb(struct _UNSUPPORT_INFO *pThis, int nType);
+extern GO_FPDF_EXPORT void GO_FPDF_CALLCONV go_un_sp_obj_cb(struct _UNSUPPORT_INFO *pThis, int nType);
+
 static inline void UNSUPPORT_INFO_SET_CALLBACK(UNSUPPORT_INFO *ui) {
 	ui->FSDK_UnSupport_Handler = &go_un_sp_obj_cb;
 }
 
-extern time_t go_time_function_cb();
+extern GO_FPDF_EXPORT time_t GO_FPDF_CALLCONV go_time_function_cb();
+
 static inline void FSDK_SetTimeFunction_SET_GO_METHOD() {
 	FSDK_SetTimeFunction(&go_time_function_cb);
 }
@@ -29,7 +32,8 @@ typedef struct GoPdfiumLocalTime {
 } GoPdfiumLocalTime;
 
 typedef const time_t ctime_t;
-extern GoPdfiumLocalTime go_local_time_function_cb(ctime_t *curTime);
+
+extern GO_FPDF_EXPORT GoPdfiumLocalTime GO_FPDF_CALLCONV go_local_time_function_cb(ctime_t *curTime);
 
 static inline struct tm* local_time_function_cb(const time_t *curTime) {
 	// Initialize a tm struct.

--- a/internal/implementation_cgo/fpdf_formfill.go
+++ b/internal/implementation_cgo/fpdf_formfill.go
@@ -4,22 +4,23 @@ package implementation_cgo
 #cgo pkg-config: pdfium
 #include "fpdf_formfill.h"
 #include <stdlib.h>
+#include "go_pdfium_cgo_export.h"
 
-extern void go_formfill_Release_cb(struct _FPDF_FORMFILLINFO *this);
-extern void go_formfill_FFI_Invalidate_cb(struct _FPDF_FORMFILLINFO *this, FPDF_PAGE page, double left, double top, double right, double bottom);
-extern void go_formfill_FFI_OutputSelectedRect_cb(struct _FPDF_FORMFILLINFO *this, FPDF_PAGE page, double left, double top, double right, double bottom);
-extern void go_formfill_FFI_SetCursor_cb(struct _FPDF_FORMFILLINFO *this, int nCursorType);
-extern int go_formfill_FFI_SetTimer_cb(struct _FPDF_FORMFILLINFO *this, int uElapse, TimerCallback lpTimerFunc);
-extern void go_formfill_FFI_KillTimer_cb(struct _FPDF_FORMFILLINFO *this, int nTimerID);
-extern FPDF_SYSTEMTIME go_formfill_FFI_GetLocalTime_cb(struct _FPDF_FORMFILLINFO *this);
-extern void go_formfill_FFI_OnChange_cb(struct _FPDF_FORMFILLINFO *this);
-extern FPDF_PAGE go_formfill_FFI_GetPage_cb(struct _FPDF_FORMFILLINFO *this, FPDF_DOCUMENT document, int nPageIndex);
-extern FPDF_PAGE go_formfill_FFI_GetCurrentPage_cb(struct _FPDF_FORMFILLINFO *this, FPDF_DOCUMENT document);
-extern int go_formfill_FFI_GetRotation_cb(struct _FPDF_FORMFILLINFO *this, FPDF_PAGE page);
-extern void go_formfill_FFI_ExecuteNamedAction_cb(struct _FPDF_FORMFILLINFO *this, FPDF_BYTESTRING namedAction);
-extern void go_formfill_FFI_SetTextFieldFocus_cb(struct _FPDF_FORMFILLINFO *this, FPDF_WIDESTRING value, FPDF_DWORD valueLen, FPDF_BOOL is_focus);
-extern void go_formfill_FFI_DoURIAction_cb(struct _FPDF_FORMFILLINFO *this, FPDF_BYTESTRING bsURI);
-extern void go_formfill_FFI_DoGoToAction_cb(struct _FPDF_FORMFILLINFO *this, int nPageIndex, int zoomMode, float* fPosArray, int sizeofArray);
+extern GO_FPDF_EXPORT void GO_FPDF_CALLCONV go_formfill_Release_cb(struct _FPDF_FORMFILLINFO *this);
+extern GO_FPDF_EXPORT void GO_FPDF_CALLCONV go_formfill_FFI_Invalidate_cb(struct _FPDF_FORMFILLINFO *this, FPDF_PAGE page, double left, double top, double right, double bottom);
+extern GO_FPDF_EXPORT void GO_FPDF_CALLCONV go_formfill_FFI_OutputSelectedRect_cb(struct _FPDF_FORMFILLINFO *this, FPDF_PAGE page, double left, double top, double right, double bottom);
+extern GO_FPDF_EXPORT void GO_FPDF_CALLCONV go_formfill_FFI_SetCursor_cb(struct _FPDF_FORMFILLINFO *this, int nCursorType);
+extern GO_FPDF_EXPORT int GO_FPDF_CALLCONV go_formfill_FFI_SetTimer_cb(struct _FPDF_FORMFILLINFO *this, int uElapse, TimerCallback lpTimerFunc);
+extern GO_FPDF_EXPORT void GO_FPDF_CALLCONV go_formfill_FFI_KillTimer_cb(struct _FPDF_FORMFILLINFO *this, int nTimerID);
+extern GO_FPDF_EXPORT FPDF_SYSTEMTIME GO_FPDF_CALLCONV go_formfill_FFI_GetLocalTime_cb(struct _FPDF_FORMFILLINFO *this);
+extern GO_FPDF_EXPORT void GO_FPDF_CALLCONV go_formfill_FFI_OnChange_cb(struct _FPDF_FORMFILLINFO *this);
+extern GO_FPDF_EXPORT FPDF_PAGE GO_FPDF_CALLCONV go_formfill_FFI_GetPage_cb(struct _FPDF_FORMFILLINFO *this, FPDF_DOCUMENT document, int nPageIndex);
+extern GO_FPDF_EXPORT FPDF_PAGE GO_FPDF_CALLCONV go_formfill_FFI_GetCurrentPage_cb(struct _FPDF_FORMFILLINFO *this, FPDF_DOCUMENT document);
+extern GO_FPDF_EXPORT int GO_FPDF_CALLCONV go_formfill_FFI_GetRotation_cb(struct _FPDF_FORMFILLINFO *this, FPDF_PAGE page);
+extern GO_FPDF_EXPORT void GO_FPDF_CALLCONV go_formfill_FFI_ExecuteNamedAction_cb(struct _FPDF_FORMFILLINFO *this, FPDF_BYTESTRING namedAction);
+extern GO_FPDF_EXPORT void GO_FPDF_CALLCONV go_formfill_FFI_SetTextFieldFocus_cb(struct _FPDF_FORMFILLINFO *this, FPDF_WIDESTRING value, FPDF_DWORD valueLen, FPDF_BOOL is_focus);
+extern GO_FPDF_EXPORT void GO_FPDF_CALLCONV go_formfill_FFI_DoURIAction_cb(struct _FPDF_FORMFILLINFO *this, FPDF_BYTESTRING bsURI);
+extern GO_FPDF_EXPORT void GO_FPDF_CALLCONV go_formfill_FFI_DoGoToAction_cb(struct _FPDF_FORMFILLINFO *this, int nPageIndex, int zoomMode, float* fPosArray, int sizeofArray);
 
 static inline void FPDF_FORMFILLINFO_SET_CB(FPDF_FORMFILLINFO *f) {
 	f->Release = &go_formfill_Release_cb;

--- a/internal/implementation_cgo/fpdf_progressive.go
+++ b/internal/implementation_cgo/fpdf_progressive.go
@@ -4,8 +4,9 @@ package implementation_cgo
 #cgo pkg-config: pdfium
 #include "fpdf_progressive.h"
 #include <stdlib.h>
+#include "go_pdfium_cgo_export.h"
 
-extern int go_progressive_render_pause_cb(struct _IFSDK_PAUSE *me);
+extern GO_FPDF_EXPORT int GO_FPDF_CALLCONV go_progressive_render_pause_cb(struct _IFSDK_PAUSE *me);
 
 static inline void IFSDK_PAUSE_SET_CB(IFSDK_PAUSE *p, char *id) {
 	p->NeedToPauseNow = &go_progressive_render_pause_cb;

--- a/internal/implementation_cgo/fpdf_save.go
+++ b/internal/implementation_cgo/fpdf_save.go
@@ -15,9 +15,10 @@ import (
 #cgo pkg-config: pdfium
 #include "fpdf_save.h"
 #include <stdlib.h>
+#include "go_pdfium_cgo_export.h"
 
 typedef const void cvoid_t;
-extern int go_writer_cb(struct FPDF_FILEWRITE_ *pThis, cvoid_t *pData, unsigned long size);
+extern GO_FPDF_EXPORT int GO_FPDF_CALLCONV go_writer_cb(struct FPDF_FILEWRITE_ *pThis, cvoid_t *pData, unsigned long size);
 
 static inline void FPDF_FILEWRITE_SET_WRITE_BLOCK(FPDF_FILEWRITE *fs) {
 	fs->WriteBlock = &go_writer_cb;

--- a/internal/implementation_cgo/go_pdfium_cgo_export.h
+++ b/internal/implementation_cgo/go_pdfium_cgo_export.h
@@ -1,0 +1,7 @@
+#if defined(WIN32)
+#define GO_FPDF_EXPORT __declspec(dllexport)
+#define GO_FPDF_CALLCONV __stdcall
+#else
+#define GO_FPDF_EXPORT
+#define GO_FPDF_CALLCONV
+#endif


### PR DESCRIPTION
I was having issues tyring to build this project for windows. It was complaining that the callback functions have already been defined and can thus not add the `dllexport` attribute.

Here is an example error:
```
cgo-gcc-export-header-prolog:123:40: error: redeclaration of 'go_formfill_FFI_GetPage_cb' cannot add 'dllexport' attribute
  123 | extern __declspec(dllexport) FPDF_PAGE go_formfill_FFI_GetPage_cb(FPDF_FORMFILLINFO* me, FPDF_DOCUMENT document, int nPageIndex);
      |                                        ^
fpdf_formfill.go:16:18: note: previous declaration is here
   16 | extern FPDF_PAGE go_formfill_FFI_GetPage_cb(struct _FPDF_FORMFILLINFO *this, FPDF_DOCUMENT document, int nPageIndex);
```

I go this problem when using the zig (cross) compiler and clang (running native on Windows).

So I made a change to add the `dllexport` required to the first definitions of these methods when targeting windows.

Using this I did get it to compile for Windows.