### PR TITLE
Fix/kill nil pointer

### DIFF
--- a/shared_tests/testdata/bug_451265.pdf
+++ b/shared_tests/testdata/bug_451265.pdf
@@ -1,0 +1,98 @@
+%PDF-1.7
+% ò¤ô
+1 0 obj <<
+  /Kids [3 0 R]
+  /Type /Pages
+  /Count 1
+>>
+endobj
+2 0 obj <<
+  /Type /Catalog
+  /Pages 1 0 R
+>>
+endobj
+3 0 obj <<
+  /Resources 11 0 R
+  /Type /Page
+  /Contents 10 0 R
+  /Parent 1 0 R
+>>
+endobj
+10 0 obj <<
+>>
+stream
+1 0 0 1 315.779 733.039 cm
+1 0 0 1 2.835 -173.614 cm
+1.04704 0 0 1.04704 0 0 cm
+/Im6 Do
+endstream
+endobj
+11 0 obj <<
+  /XObject <<
+    /Im6 12 0 R
+  >>
+>>
+endobj
+12 0 obj <<
+  /Subtype /Form
+  /Resources <<
+    /XObject <<
+      /x15 13 0 R
+    >>
+  >>
+>>
+stream
+/x15 Do
+endstream
+endobj
+13 0 obj <<
+  /Subtype /Form
+  /Resources <<
+    /Pattern <<
+      /p31 14 0 R
+    >>
+  >>
+>>
+stream
+q /Pattern cs /p31 scn /a0 gs
+0 0 224.720001 160.399994 re f
+Q
+endstream
+endobj
+14 0 obj <<
+  /PatternType 1
+  /BBox [0 0 225 161]
+  /Resources <<
+    /XObject <<
+      /x47 12 0 R
+    >>
+  >>
+>>
+stream
+/x47 Do
+endstream
+endobj
+xref
+0 15
+0000000000 65535 f 
+0000000015 00000 n 
+0000000078 00000 n 
+0000000131 00000 n 
+0000000000 65535 f 
+0000000000 65535 f 
+0000000000 65535 f 
+0000000000 65535 f 
+0000000000 65535 f 
+0000000000 65535 f 
+0000000221 00000 n 
+0000000348 00000 n 
+0000000405 00000 n 
+0000000531 00000 n 
+0000000712 00000 n 
+trailer <<
+  /Root 2 0 R
+  /Size 110
+>>
+startxref
+860
+%%EOF

--- a/webassembly/webassembly.go
+++ b/webassembly/webassembly.go
@@ -32,6 +32,7 @@ var pdfiumWasm []byte
 
 type worker struct {
 	Context   context.Context
+	Cancel    goctx.CancelFunc
 	Functions map[string]api.Function
 	Module    api.Module
 	Instance  *implementation_webassembly.PdfiumImplementation
@@ -139,8 +140,10 @@ func Init(config Config) (pdfium.Pool, error) {
 
 	factory := pool.NewPooledObjectFactory(
 		func(goctx.Context) (interface{}, error) {
+			workerCtx, cancel := goctx.WithCancel(poolContext)
 			newWorker := &worker{
-				Context: poolContext,
+				Context: workerCtx,
+				Cancel:  cancel,
 			}
 
 			moduleConfig := wazero.NewModuleConfig().
@@ -372,6 +375,11 @@ func (i *pdfiumInstance) Kill() (err error) {
 			err = fmt.Errorf("panic occurred in %s: %v", "Close", panicError)
 		}
 	}()
+
+	// Cancel the worker context to interrupt any in-flight WASM execution.
+	// For this to take effect, the caller must enable WithCloseOnContextDone
+	// on the RuntimeConfig passed to Init.
+	i.worker.Cancel()
 
 	i.pool.lock.Lock()
 	delete(i.pool.instanceRefs, i.instanceRef)

--- a/webassembly/webassembly.go
+++ b/webassembly/webassembly.go
@@ -377,11 +377,13 @@ func (i *pdfiumInstance) Kill() (err error) {
 	delete(i.pool.instanceRefs, i.instanceRef)
 	i.pool.lock.Unlock()
 
+	// Invalidate will close the module.
+	err = i.pool.workerPool.InvalidateObject(goctx.Background(), i.worker)
+
 	i.pool = nil
 	i.closed = true
 
-	// Invalidate will close the module.
-	return i.pool.workerPool.InvalidateObject(goctx.Background(), i.worker)
+	return err
 }
 
 func (i *pdfiumInstance) GetImplementation() interface{} {

--- a/webassembly/webassembly_test.go
+++ b/webassembly/webassembly_test.go
@@ -9,8 +9,10 @@ import (
 	"time"
 
 	"github.com/klippa-app/go-pdfium"
+	"github.com/klippa-app/go-pdfium/requests"
 	"github.com/klippa-app/go-pdfium/shared_tests"
 	"github.com/klippa-app/go-pdfium/webassembly"
+	"github.com/tetratelabs/wazero"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -123,6 +125,79 @@ var _ = Describe("Webassembly", func() {
 			Expect(err).To(BeNil())
 
 			// The pool should still be usable after Kill.
+			instance2, err := pool.GetInstance(time.Second * 30)
+			Expect(err).To(BeNil())
+			err = instance2.Close()
+			Expect(err).To(BeNil())
+		})
+
+		// bug_451265.pdf is a malformed PDF from the PDFium test corpus
+		// that causes pdfium to hang indefinitely during rendering.
+		// Kill() can interrupt stuck execution when the caller enables
+		// WithCloseOnContextDone on the RuntimeConfig. This works because
+		// Kill() cancels the worker's context, and WithCloseOnContextDone
+		// makes wazero respect that cancellation during execution.
+		It("interrupts a stuck WASM execution and recovers the pool", func() {
+			pool, err := webassembly.Init(webassembly.Config{
+				MinIdle:       0,
+				MaxIdle:       1,
+				MaxTotal:      1,
+				RuntimeConfig: wazero.NewRuntimeConfig().WithCloseOnContextDone(true),
+			})
+			Expect(err).To(BeNil())
+			defer pool.Close()
+
+			instance, err := pool.GetInstance(time.Second * 30)
+			Expect(err).To(BeNil())
+
+			pdfData, err := os.ReadFile("../shared_tests/testdata/bug_451265.pdf")
+			Expect(err).To(BeNil())
+
+			doc, err := instance.OpenDocument(&requests.OpenDocument{
+				File: &pdfData,
+			})
+			Expect(err).To(BeNil())
+
+			// Start rendering in a goroutine. This hangs indefinitely
+			// because the PDF triggers a stuck state in pdfium.
+			renderDone := make(chan error, 1)
+			go func() {
+				_, renderErr := instance.RenderToFile(&requests.RenderToFile{
+					RenderPageInDPI: &requests.RenderPageInDPI{
+						Page: requests.Page{
+							ByIndex: &requests.PageByIndex{
+								Document: doc.Document,
+								Index:    0,
+							},
+						},
+						DPI: 72,
+					},
+					OutputFormat:  requests.RenderToFileOutputFormatJPG,
+					OutputTarget:  requests.RenderToFileOutputTargetBytes,
+					OutputQuality: 50,
+				})
+				renderDone <- renderErr
+			}()
+
+			// Give the render a moment to get stuck.
+			time.Sleep(500 * time.Millisecond)
+
+			// Kill must complete promptly — not block forever.
+			killDone := make(chan error, 1)
+			go func() {
+				killDone <- instance.Kill()
+			}()
+
+			select {
+			case err := <-killDone:
+				// Kill may return an error (e.g. context canceled) but
+				// must not hang or panic.
+				_ = err
+			case <-time.After(5 * time.Second):
+				Fail("Kill() did not return within 5 seconds — WASM execution was not interrupted")
+			}
+
+			// The pool should still be usable: get a fresh instance.
 			instance2, err := pool.GetInstance(time.Second * 30)
 			Expect(err).To(BeNil())
 			err = instance2.Close()

--- a/webassembly/webassembly_test.go
+++ b/webassembly/webassembly_test.go
@@ -101,6 +101,34 @@ var _ = Describe("Webassembly", func() {
 			}, NodeTimeout(time.Second))
 		})
 	})
+
+	Context("Kill", func() {
+		// Kill() previously set i.pool = nil before calling
+		// i.pool.workerPool.InvalidateObject(), causing a nil pointer
+		// dereference on every call. The deferred recover() caught the
+		// panic silently, but the module was never actually invalidated.
+		It("does not panic when called on an idle instance", func() {
+			pool, err := webassembly.Init(webassembly.Config{
+				MinIdle:  0,
+				MaxIdle:  1,
+				MaxTotal: 1,
+			})
+			Expect(err).To(BeNil())
+			defer pool.Close()
+
+			instance, err := pool.GetInstance(time.Second * 30)
+			Expect(err).To(BeNil())
+
+			err = instance.Kill()
+			Expect(err).To(BeNil())
+
+			// The pool should still be usable after Kill.
+			instance2, err := pool.GetInstance(time.Second * 30)
+			Expect(err).To(BeNil())
+			err = instance2.Close()
+			Expect(err).To(BeNil())
+		})
+	})
 })
 
 var _ = AfterEach(func() {


### PR DESCRIPTION
`Kill()` currently always panics because it sets `i.pool` to nil before calling `i.pool.workerPool.InvalidateObject(goctx.Background(), i.worker)`. (This is caught by `Kill`'s deferred recoverer, so at least an error is returned, but the error is always returned.) 

Additionally, this isn't enough to actually kill a stuck pdfium process in WASM, the context must be cancelled. Further if the caller to `Init()` has not set `RuntimeConfig: wazero.NewRuntimeConfig().WithCloseOnContextDone(true)` then Go will be waiting for WASM to return before checking for context cancellation, and if we are stuck in an infinite loop in WASM this will block forever.

An early version of this turned on WithCloseOnContextDone inside of Init, but we decided it's probably best to not make that decision for all users, though without it there are instances where Kill() will simply not work. 

The test includes a pdf file "bug_451265.pdf", which came from PDFium's [test corpus](https://pdfium.googlesource.com/pdfium/+/refs/heads/chromium/4338/testing/resources), and triggers an infinite loop in PDFium. I suppose if they fix that bug in the future the test here won't be testing the same thing, the render might succeed or error quickly and then `Kill()` will be called on a now-idle instance, but the test shouldn't start failing in that case.

I'm also curious about why this pdf file is in PDFium's test corpus yet rendering it still causes an infinite hang in WASM. Maybe that's a separate bug in the WASM port? 