### PR TITLE
Fix FileWriters map conflict in WASM implementation

### DIFF
--- a/internal/implementation_webassembly/data.go
+++ b/internal/implementation_webassembly/data.go
@@ -12,6 +12,7 @@ import (
 	"github.com/klippa-app/go-pdfium/enums"
 	"github.com/klippa-app/go-pdfium/structs"
 
+	"github.com/tetratelabs/wazero/api"
 	"golang.org/x/text/encoding/unicode"
 	"golang.org/x/text/transform"
 )
@@ -70,13 +71,16 @@ type FileWriterRef struct {
 }
 
 var FileWriters = struct {
-	Refs    map[uint32]*FileWriterRef
-	Counter uint32
-	Mutex   *sync.Mutex
+	Refs  map[FileWriterKey]*FileWriterRef
+	Mutex *sync.Mutex
 }{
-	Refs:    map[uint32]*FileWriterRef{},
-	Counter: 0,
-	Mutex:   &sync.Mutex{},
+	Refs:  map[FileWriterKey]*FileWriterRef{},
+	Mutex: &sync.Mutex{},
+}
+
+type FileWriterKey struct {
+	Module  api.Module
+	Pointer uint32
 }
 
 type CString struct {

--- a/internal/implementation_webassembly/fpdf_save.go
+++ b/internal/implementation_webassembly/fpdf_save.go
@@ -76,8 +76,10 @@ func (p *PdfiumImplementation) FPDF_SaveWithVersion(request *requests.FPDF_SaveW
 		FileWrite: &fileWriterPointer,
 	}
 
+	key := FileWriterKey{Module: p.Module, Pointer: uint32(fileWriterPointer)}
+
 	FileWriters.Mutex.Lock()
-	FileWriters.Refs[uint32(fileWriterPointer)] = fileWriterRef
+	FileWriters.Refs[key] = fileWriterRef
 	FileWriters.Mutex.Unlock()
 
 	defer func() {
@@ -85,7 +87,7 @@ func (p *PdfiumImplementation) FPDF_SaveWithVersion(request *requests.FPDF_SaveW
 		currentWriter = nil
 
 		FileWriters.Mutex.Lock()
-		delete(FileWriters.Refs, uint32(fileWriterPointer))
+		delete(FileWriters.Refs, key)
 		FileWriters.Mutex.Unlock()
 
 		if curFile != nil {

--- a/webassembly/imports/callbacks.go
+++ b/webassembly/imports/callbacks.go
@@ -82,9 +82,11 @@ func (cb FPDF_FILEWRITE_CB) Call(ctx context.Context, mod api.Module, stack []ui
 
 	mem := mod.Memory()
 
+	key := implementation_webassembly.FileWriterKey{Module: mod, Pointer: fileWritePointer}
+
 	// Check if we have the file referenced in param.
 	implementation_webassembly.FileWriters.Mutex.Lock()
-	openWriter, ok := implementation_webassembly.FileWriters.Refs[fileWritePointer]
+	openWriter, ok := implementation_webassembly.FileWriters.Refs[key]
 	implementation_webassembly.FileWriters.Mutex.Unlock()
 	if !ok {
 		stack[0] = uint64(0)


### PR DESCRIPTION
The webassembly implementation of `FileWriters` uses memory address to key a `FileWriterRef`. When multiple instances from a pool open the same document and attempt to `SaveAsCopy` or `SaveWithVersion`, this address may be identical. This results in "save of document failed" errors.

The commit here uses a composite key in the `Ref` map:

```
(api.Module, uint32)
```

By scoping the Ref table to each instance, I believe we can avoid the possibility of a conflict.

> Note: I opted for an exported composite key struct rather than a nested map
> because the nested map introduces complications with key deletion / leaks.
> I'm open to suggestion if there is a different preference.

---

I created a branch that demonstrates the issue:
- https://github.com/mattoberle/go-pdfium/blob/filewriters-example/examples/webassembly/main.go

Reproduction requires a slow-saving PDF (also added in the example branch).