### PR TITLE
webassembly: allow caller-provided context

### DIFF
--- a/webassembly/webassembly.go
+++ b/webassembly/webassembly.go
@@ -21,8 +21,6 @@ import (
 	pool "github.com/jolestar/go-commons-pool/v2"
 	"github.com/tetratelabs/wazero"
 	"github.com/tetratelabs/wazero/api"
-	"github.com/tetratelabs/wazero/experimental"
-	"github.com/tetratelabs/wazero/experimental/logging"
 	"github.com/tetratelabs/wazero/imports/wasi_snapshot_preview1"
 	"golang.org/x/net/context"
 )
@@ -39,6 +37,10 @@ type worker struct {
 }
 
 type Config struct {
+	// Context is used to initialize the wazero runtime and as the parent
+	// context for its workers. It must remain valid for the lifetime of the
+	// pool. If nil, context.Background is used.
+	Context       goctx.Context
 	MinIdle       int
 	MaxIdle       int
 	MaxTotal      int
@@ -112,11 +114,10 @@ func Init(config Config) (pdfium.Pool, error) {
 		config.RuntimeConfig = wazero.NewRuntimeConfig()
 	}
 
-	poolContext := experimental.WithFunctionListenerFactory(context.Background(), logging.NewLoggingListenerFactory(os.Stdout))
-
-	// Uncomment the line below if you want function call logging,
-	// useful for debugging.
-	poolContext = context.Background()
+	poolContext := config.Context
+	if poolContext == nil {
+		poolContext = context.Background()
+	}
 
 	runtime := wazero.NewRuntimeWithConfig(poolContext, config.RuntimeConfig)
 

--- a/webassembly/webassembly_test.go
+++ b/webassembly/webassembly_test.go
@@ -2,6 +2,7 @@ package webassembly_test
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -80,6 +81,31 @@ var _ = Describe("Webassembly", func() {
 	shared_tests.Import()
 
 	Context("pooling", func() {
+		It("uses the configured context for workers", func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			pool, err := webassembly.Init(webassembly.Config{
+				Context:       ctx,
+				MinIdle:       0,
+				MaxIdle:       1,
+				MaxTotal:      1,
+				RuntimeConfig: runtimeConfig().WithCloseOnContextDone(true),
+			})
+			Expect(err).To(BeNil())
+			DeferCleanup(func() {
+				Expect(pool.Close()).To(Succeed())
+			})
+
+			cancel()
+			instance, err := pool.GetInstance(time.Second * 30)
+			if instance != nil {
+				DeferCleanup(func() {
+					Expect(instance.Close()).To(Succeed())
+				})
+			}
+			Expect(err).To(HaveOccurred())
+			Expect(errors.Is(err, context.Canceled)).To(BeTrue())
+		})
+
 		When("a pool is opened", func() {
 			var TestPool pdfium.Pool
 


### PR DESCRIPTION
Allow callers to provide a context when initializing a WebAssembly pool. The context is passed to wazero and used as the parent context for workers, enabling wazero features configured through context (such as function listeners and custom memory allocators), as well as cancellation through `WithCloseOnContextDone`.

A nil context retains the existing `context.Background()` behavior. The source-level debug toggle for function-call logging is no longer needed, as callers can configure the listener factory on the supplied context instead.

A regression test covers worker cancellation through the configured context. All tests pass.