### PR TITLE
webassembly: allow omitting embedded WASM from linked binaries

### DIFF
--- a/webassembly/webassembly.go
+++ b/webassembly/webassembly.go
@@ -72,11 +72,23 @@ var multiThreadedMutex = &sync.Mutex{}
 // allow it. If the pool has been exhausted. It will wait until a worker becomes
 // available. So it's important that you close instances when you're done with them.
 func Init(config Config) (pdfium.Pool, error) {
-	// Set config defaults.
 	if config.WASM == nil {
 		config.WASM = pdfiumWasm
 	}
+	return initWithConfig(config)
+}
 
+// InitWithWASM will return a multithreaded webassembly pool using the module in
+// Config.WASM. Unlike Init, it does not reference the embedded default module,
+// allowing applications that provide their own module to omit it at link time.
+func InitWithWASM(config Config) (pdfium.Pool, error) {
+	if config.WASM == nil {
+		return nil, errors.New("webassembly module must be provided")
+	}
+	return initWithConfig(config)
+}
+
+func initWithConfig(config Config) (pdfium.Pool, error) {
 	// Mount the full root by default.
 	if config.FSConfig == nil {
 		config.FSConfig = wazero.NewFSConfig()

--- a/webassembly/webassembly_test.go
+++ b/webassembly/webassembly_test.go
@@ -80,6 +80,14 @@ var _ = AfterSuite(func() {
 var _ = Describe("Webassembly", func() {
 	shared_tests.Import()
 
+	Context("custom WASM", func() {
+		It("requires a configured module", func() {
+			pool, err := webassembly.InitWithWASM(webassembly.Config{})
+			Expect(pool).To(BeNil())
+			Expect(err).To(MatchError("webassembly module must be provided"))
+		})
+	})
+
 	Context("pooling", func() {
 		It("uses the configured context for workers", func() {
 			ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
`webassembly.Config.WASM` already allows an application to provide its own PDFium module. One use case is a reduced module tailored to the PDFium APIs the application needs, reducing both distribution size and WebAssembly compilation work.

With the current `Init` entry point, however, the application still ships both modules: its own module and go-pdfium's embedded default. `Init` references the default as its nil fallback, which keeps it reachable to the Go linker even when `Config.WASM` is always set.

To make the caller-provided module a true replacement, this PR adds `InitWithWASM`. It requires a non-nil `Config.WASM` and uses the same initialization path as `Init`, but has no reference to the embedded default.

A linker check confirms that a binary using only `InitWithWASM` no longer contains the bundled module, removing roughly 5 MB. 