### PR TITLE
fix: resolve build failure on 32-bit architectures (386/arm) due to oversized Cgo array type- #335

### DIFF
--- a/internal/implementation_cgo/fpdf_formfill.go
+++ b/internal/implementation_cgo/fpdf_formfill.go
@@ -47,9 +47,10 @@ static inline void FPDF_FORMFILLINFO_CALL_TIMER(TimerCallback t, int id) {
 import "C"
 import (
 	"errors"
+	"unsafe"
+
 	"github.com/klippa-app/go-pdfium/enums"
 	"github.com/klippa-app/go-pdfium/references"
-	"unsafe"
 
 	"github.com/klippa-app/go-pdfium/requests"
 	"github.com/klippa-app/go-pdfium/responses"
@@ -418,7 +419,7 @@ func go_formfill_FFI_DoGoToAction_cb(me *C.FPDF_FORMFILLINFO, nPageIndex C.int, 
 		return
 	}
 
-	target := (*[1<<25 - 1]float32)(unsafe.Pointer(fPosArray))[:sizeofArray:sizeofArray]
+	target := unsafe.Slice((*float32)(unsafe.Pointer(fPosArray)), sizeofArray)
 	pos := make([]float32, int(sizeofArray))
 	for i := range pos {
 		pos[i] = float32(target[i])

--- a/internal/implementation_cgo/implementation.go
+++ b/internal/implementation_cgo/implementation.go
@@ -102,7 +102,7 @@ func InitLibrary(config *pdfium.LibraryConfig) {
 			// Create array of length config.UserFontPaths + 1 for the NULL terminator.
 			cArray := C.malloc(C.size_t(len(config.UserFontPaths)+1) * C.size_t(unsafe.Sizeof(uintptr(0))))
 
-			cFonts := (*[1<<30 - 1]*C.char)(cArray)
+			cFonts := unsafe.Slice((**C.char)(cArray), len(config.UserFontPaths)+1)
 			for i := range config.UserFontPaths {
 				cFonts[i] = C.CString(config.UserFontPaths[i])
 			}


### PR DESCRIPTION
## Problem

On 32-bit target architectures (`GOARCH=386`, `GOARCH=arm`), the build fails with:

```
github.com/klippa-app/go-pdfium/.../internal/implementation_cgo/implementation.go:105:4:
    type [1073741823]*_Ctype_char too large
```

### Root Cause

Two files use the legacy pattern of casting a C pointer to a large fixed-size Go array type in order to construct a slice:

```go
// internal/implementation_cgo/implementation.go
cFonts := (*[1<<30 - 1]*C.char)(cArray)

// internal/implementation_cgo/fpdf_formfill.go
target := (*[1<<25 - 1]float32)(unsafe.Pointer(fPosArray))[:sizeofArray:sizeofArray]
```

On 64-bit architectures (amd64, arm64) pointers are 8 bytes, so `1<<30 * 8 = 8 GB` and the type declaration compiles fine. On 32-bit architectures pointers are 4 bytes, and `1<<30 * 4 = 4 GB` exceeds the 2 GB (`2^31 - 1` bytes) maximum allowable type size, causing the compile-time error.

## Fix

Replace both sites with the `unsafe.Slice` builtin (available since Go 1.17), which constructs a Go slice directly from a pointer and length without requiring a fixed-size array type:

```go
// Before
cFonts := (*[1<<30 - 1]*C.char)(cArray)

// After
cFonts := unsafe.Slice((**C.char)(cArray), len(config.UserFontPaths)+1)
```

```go
// Before
target := (*[1<<25 - 1]float32)(unsafe.Pointer(fPosArray))[:sizeofArray:sizeofArray]

// After
target := unsafe.Slice((*float32)(unsafe.Pointer(fPosArray)), sizeofArray)
```

`unsafe.Slice` is safe, idiomatic, and architecture-independent — it is precisely the API the Go team introduced to replace this pattern.

## Affected Architectures / Platforms

- `GOOS=windows GOARCH=386`
- `GOOS=android GOARCH=arm`
- `GOOS=android GOARCH=386`
- Any other 32-bit target with CGo enabled

## Changes

| File | Change |
|------|--------|
| `internal/implementation_cgo/implementation.go` | Replace `(*[1<<30-1]*C.char)(cArray)` with `unsafe.Slice((**C.char)(cArray), n)` |
| `internal/implementation_cgo/fpdf_formfill.go` | Replace `(*[1<<25-1]float32)(ptr)[:n:n]` with `unsafe.Slice((*float32)(ptr), n)` |

No behaviour changes — semantics are identical; only the compilation strategy differs.