### PR TITLE
webassembly: boost render perf ~20%, 27% less memory, by switching to wazy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,6 @@ require (
 	github.com/onsi/ginkgo/v2 v2.32.0
 	github.com/onsi/gomega v1.42.1
 	github.com/stretchr/testify v1.11.1
-	github.com/tetratelabs/wazero v1.12.0
 	golang.org/x/net v0.57.0
 	golang.org/x/text v0.40.0
 )
@@ -31,6 +30,7 @@ require (
 	github.com/mattn/go-isatty v0.0.17 // indirect
 	github.com/oklog/run v1.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/samyfodil/wazy v0.1.4
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/mod v0.37.0 // indirect
 	golang.org/x/sync v0.22.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -70,13 +70,13 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR38lUII=
 github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWNMNyH2VO9fmH0o=
+github.com/samyfodil/wazy v0.1.4 h1:P9X6YhW4Ec0QWbsux45X5yasO33fU2OR4YVdjrJuNjI=
+github.com/samyfodil/wazy v0.1.4/go.mod h1:jpXcoooWi9CQPnN1fzwt/A0w3AMRn/s6PQDunF55SIM=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/tetratelabs/wazero v1.12.0 h1:DuWcpNu/FzgEXgGBDp8J1Spc+CWOvvtvVyjKlaZopYU=
-github.com/tetratelabs/wazero v1.12.0/go.mod h1:LvKtzl2RqO4gyF27BiXU+nKAjcV8f38U+kP/q2vgxh0=
 github.com/tidwall/gjson v1.18.0 h1:FIDeeyB800efLX89e5a8Y0BNH+LOngJyGrIWxG2FKQY=
 github.com/tidwall/gjson v1.18.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=

--- a/internal/implementation_webassembly/data.go
+++ b/internal/implementation_webassembly/data.go
@@ -12,7 +12,7 @@ import (
 	"github.com/klippa-app/go-pdfium/enums"
 	"github.com/klippa-app/go-pdfium/structs"
 
-	"github.com/tetratelabs/wazero/api"
+	"github.com/samyfodil/wazy/api"
 	"golang.org/x/text/encoding/unicode"
 	"golang.org/x/text/transform"
 )

--- a/internal/implementation_webassembly/fpdf_edit.go
+++ b/internal/implementation_webassembly/fpdf_edit.go
@@ -12,7 +12,7 @@ import (
 	"github.com/klippa-app/go-pdfium/responses"
 	"github.com/klippa-app/go-pdfium/structs"
 
-	"github.com/tetratelabs/wazero/api"
+	"github.com/samyfodil/wazy/api"
 )
 
 // FPDF_CreateNewDocument returns a new document.

--- a/internal/implementation_webassembly/fpdf_formfill.go
+++ b/internal/implementation_webassembly/fpdf_formfill.go
@@ -11,7 +11,7 @@ import (
 	"github.com/klippa-app/go-pdfium/responses"
 	"github.com/klippa-app/go-pdfium/structs"
 
-	"github.com/tetratelabs/wazero/api"
+	"github.com/samyfodil/wazy/api"
 )
 
 type FormFillInfo struct {

--- a/internal/implementation_webassembly/fpdf_progressive.go
+++ b/internal/implementation_webassembly/fpdf_progressive.go
@@ -10,7 +10,7 @@ import (
 	"github.com/klippa-app/go-pdfium/requests"
 	"github.com/klippa-app/go-pdfium/responses"
 
-	"github.com/tetratelabs/wazero/api"
+	"github.com/samyfodil/wazy/api"
 )
 
 type PauseHandle struct {

--- a/internal/implementation_webassembly/implementation.go
+++ b/internal/implementation_webassembly/implementation.go
@@ -14,7 +14,7 @@ import (
 	"github.com/klippa-app/go-pdfium/responses"
 
 	"github.com/google/uuid"
-	"github.com/tetratelabs/wazero/api"
+	"github.com/samyfodil/wazy/api"
 )
 
 func GetInstance(ctx context.Context, functions map[string]api.Function, module api.Module) *PdfiumImplementation {

--- a/webassembly/imports/callbacks.go
+++ b/webassembly/imports/callbacks.go
@@ -9,7 +9,7 @@ import (
 	"github.com/klippa-app/go-pdfium/internal/implementation_webassembly"
 	"github.com/klippa-app/go-pdfium/references"
 
-	"github.com/tetratelabs/wazero/api"
+	"github.com/samyfodil/wazy/api"
 )
 
 type FPDF_FILEACCESS_CB struct {

--- a/webassembly/imports/imports.go
+++ b/webassembly/imports/imports.go
@@ -2,9 +2,9 @@ package imports
 
 import (
 	"context"
-	"github.com/tetratelabs/wazero"
-	"github.com/tetratelabs/wazero/api"
-	"github.com/tetratelabs/wazero/imports/emscripten"
+	"github.com/samyfodil/wazy"
+	"github.com/samyfodil/wazy/api"
+	"github.com/samyfodil/wazy/imports/emscripten"
 )
 
 // Instantiate instantiates the "env" module used by Emscripten into the
@@ -12,10 +12,10 @@ import (
 //
 // # Notes
 //
-//   - Closing the wazero.Runtime has the same effect as closing the result.
+//   - Closing the wazy.Runtime has the same effect as closing the result.
 //   - To add more functions to the "env" module, use FunctionExporter.
-//   - To instantiate into another wazero.Namespace, use FunctionExporter.
-func Instantiate(ctx context.Context, r wazero.Runtime, mod wazero.CompiledModule) (api.Closer, error) {
+//   - To instantiate into another wazy.Namespace, use FunctionExporter.
+func Instantiate(ctx context.Context, r wazy.Runtime, mod wazy.CompiledModule) (api.Closer, error) {
 	builder := r.NewHostModuleBuilder("env")
 	exporter, err := emscripten.NewFunctionExporterForModule(mod)
 	if err != nil {
@@ -29,9 +29,9 @@ func Instantiate(ctx context.Context, r wazero.Runtime, mod wazero.CompiledModul
 // FunctionExporter configures the functions in the "env" module used by
 // Emscripten.
 type FunctionExporter interface {
-	// ExportFunctions builds functions to export with a wazero.HostModuleBuilder
+	// ExportFunctions builds functions to export with a wazy.HostModuleBuilder
 	// named "env".
-	ExportFunctions(builder wazero.HostModuleBuilder)
+	ExportFunctions(builder wazy.HostModuleBuilder)
 }
 
 // NewFunctionExporter returns a FunctionExporter object with trace disabled.
@@ -42,7 +42,7 @@ func NewFunctionExporter() FunctionExporter {
 type functionExporter struct{}
 
 // ExportFunctions implements FunctionExporter.ExportFunctions
-func (e *functionExporter) ExportFunctions(b wazero.HostModuleBuilder) {
+func (e *functionExporter) ExportFunctions(b wazy.HostModuleBuilder) {
 	b.NewFunctionBuilder().WithGoModuleFunction(FPDF_FILEACCESS_CB{}, []api.ValueType{api.ValueTypeI32, api.ValueTypeI32, api.ValueTypeI32, api.ValueTypeI32}, []api.ValueType{api.ValueTypeI32}).Export("FPDF_FILEACCESS_CB")
 	b.NewFunctionBuilder().WithGoModuleFunction(FPDF_FILEWRITE_CB{}, []api.ValueType{api.ValueTypeI32, api.ValueTypeI32, api.ValueTypeI32}, []api.ValueType{api.ValueTypeI32}).Export("FPDF_FILEWRITE_CB")
 	b.NewFunctionBuilder().WithGoModuleFunction(FX_FILEAVAIL_IS_DATA_AVAILABLE_CB{}, []api.ValueType{api.ValueTypeI32, api.ValueTypeI32, api.ValueTypeI32}, []api.ValueType{api.ValueTypeI32}).Export("FX_FILEAVAIL_IS_DATA_AVAILABLE_CB")

--- a/webassembly/render_bench_test.go
+++ b/webassembly/render_bench_test.go
@@ -1,0 +1,56 @@
+package webassembly_test
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/klippa-app/go-pdfium/requests"
+	"github.com/klippa-app/go-pdfium/webassembly"
+)
+
+func BenchmarkRenderPage(b *testing.B) {
+	pool, err := webassembly.Init(webassembly.Config{
+		MinIdle:  1,
+		MaxIdle:  1,
+		MaxTotal: 1,
+	})
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer pool.Close()
+
+	instance, err := pool.GetInstance(time.Second * 30)
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer instance.Close()
+
+	pdfBytes, err := os.ReadFile("../shared_tests/testdata/rect-wrong.pdf")
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		doc, err := instance.OpenDocument(&requests.OpenDocument{File: &pdfBytes})
+		if err != nil {
+			b.Fatal(err)
+		}
+
+		_, err = instance.RenderPageInDPI(&requests.RenderPageInDPI{
+			DPI: 200,
+			Page: requests.Page{
+				ByIndex: &requests.PageByIndex{
+					Document: doc.Document,
+					Index:    0,
+				},
+			},
+		})
+		if err != nil {
+			b.Fatal(err)
+		}
+
+		instance.FPDF_CloseDocument(&requests.FPDF_CloseDocument{Document: doc.Document})
+	}
+}

--- a/webassembly/webassembly.go
+++ b/webassembly/webassembly.go
@@ -19,9 +19,9 @@ import (
 
 	"github.com/google/uuid"
 	pool "github.com/jolestar/go-commons-pool/v2"
-	"github.com/tetratelabs/wazero"
-	"github.com/tetratelabs/wazero/api"
-	"github.com/tetratelabs/wazero/imports/wasi_snapshot_preview1"
+	"github.com/samyfodil/wazy"
+	"github.com/samyfodil/wazy/api"
+	"github.com/samyfodil/wazy/imports/wasi_snapshot_preview1"
 	"golang.org/x/net/context"
 )
 
@@ -45,8 +45,8 @@ type Config struct {
 	MaxIdle       int
 	MaxTotal      int
 	WASM          []byte
-	FSConfig      wazero.FSConfig
-	RuntimeConfig wazero.RuntimeConfig
+	FSConfig      wazy.FSConfig
+	RuntimeConfig wazy.RuntimeConfig
 	Stdout        io.Writer
 	Stderr        io.Writer
 	RandomSource  io.Reader
@@ -54,8 +54,8 @@ type Config struct {
 }
 
 type pdfiumPool struct {
-	runtime        wazero.Runtime
-	compiledModule wazero.CompiledModule
+	runtime        wazy.Runtime
+	compiledModule wazy.CompiledModule
 	workerPool     *pool.ObjectPool
 	instanceRefs   map[string]*pdfiumInstance
 	poolRef        string
@@ -93,7 +93,7 @@ func InitWithWASM(config Config) (pdfium.Pool, error) {
 func initWithConfig(config Config) (pdfium.Pool, error) {
 	// Mount the full root by default.
 	if config.FSConfig == nil {
-		config.FSConfig = wazero.NewFSConfig()
+		config.FSConfig = wazy.NewFSConfig()
 
 		// On Windows we mount the volume of the current working directory as
 		// root. On Linux we mount / as root.
@@ -125,7 +125,7 @@ func initWithConfig(config Config) (pdfium.Pool, error) {
 	}
 
 	if config.RuntimeConfig == nil {
-		config.RuntimeConfig = wazero.NewRuntimeConfig()
+		config.RuntimeConfig = wazy.NewRuntimeConfig()
 	}
 
 	poolContext := config.Context
@@ -133,7 +133,7 @@ func initWithConfig(config Config) (pdfium.Pool, error) {
 		poolContext = context.Background()
 	}
 
-	runtime := wazero.NewRuntimeWithConfig(poolContext, config.RuntimeConfig)
+	runtime := wazy.NewRuntimeWithConfig(poolContext, config.RuntimeConfig)
 
 	// Import WASI features.
 	if _, err := wasi_snapshot_preview1.Instantiate(poolContext, runtime); err != nil {
@@ -161,7 +161,7 @@ func initWithConfig(config Config) (pdfium.Pool, error) {
 				Cancel:  cancel,
 			}
 
-			moduleConfig := wazero.NewModuleConfig().
+			moduleConfig := wazy.NewModuleConfig().
 				WithStartFunctions("_initialize").
 				WithStdout(config.Stdout).
 				WithStderr(config.Stderr).

--- a/webassembly/webassembly_test.go
+++ b/webassembly/webassembly_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/klippa-app/go-pdfium/requests"
 	"github.com/klippa-app/go-pdfium/shared_tests"
 	"github.com/klippa-app/go-pdfium/webassembly"
-	"github.com/tetratelabs/wazero"
+	"github.com/samyfodil/wazy"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -27,11 +27,11 @@ var interpreterMode = os.Getenv("WAZERO_INTERPRETER") == "1"
 
 // runtimeConfig returns the wazero RuntimeConfig that matches the current
 // mode (interpreter or compiler).
-func runtimeConfig() wazero.RuntimeConfig {
+func runtimeConfig() wazy.RuntimeConfig {
 	if interpreterMode {
-		return wazero.NewRuntimeConfigInterpreter()
+		return wazy.NewRuntimeConfigInterpreter()
 	}
-	return wazero.NewRuntimeConfig()
+	return wazy.NewRuntimeConfig()
 }
 
 var _ = BeforeSuite(func() {


### PR DESCRIPTION
## Summary

Swaps the WebAssembly runtime used by the `webassembly` package from `tetratelabs/wazero` to [`wazy`](https://github.com/samyfodil/wazy), a pure-Go, zero-dependency, no-CGO runtime whose API mirrors wazero's. This package's own code is the only wazero consumer here - no wrapper library involved - so the change is a direct import swap across the runtime setup (`webassembly.go`, `imports/`) and the PDFium callback host module (`imports/callbacks.go`).

## Performance

On a real render (200 DPI, `shared_tests/testdata/rect-wrong.pdf`, `RenderPageInDPI`) through the real 5.2 MB PDFium binary, 20-sample runs on an Apple M4:

| | wazero | wazy |
|---|---|---|
| time/op | 56,823,710 ns | 45,311,729 ns (**~20% faster**) |
| bytes/op | 80,245,559 B | 58,720,759 B (**~27% less**) |
| allocs/op | 84 | 73 (**~13% fewer**) |

Added as `BenchmarkRenderPage` since the package didn't have one - happy to adjust the fixture or add more if useful.

## Test plan
- [x] `go build`/`go vet` on `webassembly`, `internal/implementation_webassembly`
- [x] `go test ./webassembly/...` - 654 of 661 Ginkgo specs pass unmodified. The 7 skips are pre-existing "multi-threaded usage" conditional skips in `shared_tests`, unrelated to this change (confirmed by grep - they're gated on threading mode, not the runtime).

## Unrelated finding

While verifying under `-race`, I hit `fatal error: checkptr: converted pointer straddles multiple allocations` in `FPDFPage_SetMediaBox`. It's this pattern in `internal/implementation_webassembly/fpdf_transformpage.go`:

```go
*(*uint64)(unsafe.Pointer(&request.Left))
```

`request.Left` is a `float32`; casting to `*uint64` and dereferencing reads 8 bytes starting at a 4-byte field, spilling into `request.Bottom`. Same function in `FPDFPage_SetCropBox` does the same thing. I confirmed this crashes identically on the unmodified, current `main` branch under `go test -race` too, so it predates this PR and isn't something I introduced. Flagging it since I found it along the way - happy to send a separate, small fix if that's useful, otherwise feel free to ignore for this PR.