### PR TITLE
Fix UserFontPaths not properly terminating the list in CGO

### DIFF
--- a/internal/implementation_cgo/implementation.go
+++ b/internal/implementation_cgo/implementation.go
@@ -152,6 +152,11 @@ func InitLibrary(config *pdfium.LibraryConfig) {
 				cFonts[i] = C.CString(config.UserFontPaths[i])
 			}
 
+			// malloc does not zero its result, so write the NULL terminator
+			// explicitly. PDFium walks the array until it reads a NULL entry,
+			// nothing communicates the length to it.
+			cFonts[len(config.UserFontPaths)] = nil
+
 			libraryConfig.m_pUserFontPaths = (**C.char)(cArray)
 		}
 


### PR DESCRIPTION
Fixes #352 